### PR TITLE
Fix TransactionTooLargeException on activity stop with large contact lists

### DIFF
--- a/app/src/main/java/com/github/yuukis/businessmap/app/ContactsMapFragment.java
+++ b/app/src/main/java/com/github/yuukis/businessmap/app/ContactsMapFragment.java
@@ -90,6 +90,11 @@ public class ContactsMapFragment extends SupportMapFragment implements
 			mMap = googleMap;
 			setUpMap();
 			setUpMapInfoWindow();
+			// The map becomes ready asynchronously, possibly after the
+			// Activity already tried (and, since mMap was still null,
+			// failed) to draw markers for the current contacts list.
+			// Draw them now that we actually have a map to draw on.
+			notifyDataSetChanged();
 		}
 	}
 

--- a/app/src/main/java/com/github/yuukis/businessmap/app/ContactsTaskFragment.java
+++ b/app/src/main/java/com/github/yuukis/businessmap/app/ContactsTaskFragment.java
@@ -133,6 +133,16 @@ public class ContactsTaskFragment extends Fragment {
 		return mRunning;
 	}
 
+	/**
+	 * Returns the contacts list already loaded by this retained fragment, or
+	 * null if {@link #start()} has never completed at least once. Lets a
+	 * recreated Activity adopt the in-memory result directly instead of
+	 * re-querying contacts on every configuration change.
+	 */
+	public List<ContactsItem> getContactsList() {
+		return mContactsList;
+	}
+
 	private void setRunning(boolean running) {
 		mRunning = running;
 		setProgressBarVisibie(mRunning);

--- a/app/src/main/java/com/github/yuukis/businessmap/app/MainActivity.java
+++ b/app/src/main/java/com/github/yuukis/businessmap/app/MainActivity.java
@@ -17,7 +17,6 @@
  */
 package com.github.yuukis.businessmap.app;
 
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -48,7 +47,6 @@ public class MainActivity extends AppCompatActivity implements
 
 	public static final String KEY_CONTACTS_GROUP_ID = "contacts_group_id";
 	private static final String KEY_NAVIGATION_INDEX = "navigation_index";
-	private static final String KEY_CONTACTS_LIST = "contacts_list";
 
 	private List<ContactsGroup> mGroupList;
 	private List<ContactsItem> mContactsList;
@@ -136,7 +134,6 @@ public class MainActivity extends AppCompatActivity implements
 	protected void onSaveInstanceState(Bundle outState) {
 		int navigationIndex = getSupportActionBar().getSelectedNavigationIndex();
 		outState.putInt(KEY_NAVIGATION_INDEX, navigationIndex);
-		outState.putSerializable(KEY_CONTACTS_LIST, (Serializable) mContactsList);
 		super.onSaveInstanceState(outState);
 	}
 
@@ -185,7 +182,6 @@ public class MainActivity extends AppCompatActivity implements
 		return mCurrentGroupContactsList;
 	}
 
-	@SuppressWarnings("unchecked")
 	private void initialize(Bundle savedInstanceState) {
 		Bundle args = getIntent().getExtras();
 
@@ -206,8 +202,6 @@ public class MainActivity extends AppCompatActivity implements
 		int navigationIndex = 0;
 		if (savedInstanceState != null) {
 			navigationIndex = savedInstanceState.getInt(KEY_NAVIGATION_INDEX);
-			mContactsList = (List<ContactsItem>) savedInstanceState
-					.getSerializable(KEY_CONTACTS_LIST);
 		} else if (args != null) {
 			if (args.containsKey(KEY_CONTACTS_GROUP_ID)) {
 				long groupId = args.getLong(KEY_CONTACTS_GROUP_ID);

--- a/app/src/main/java/com/github/yuukis/businessmap/app/MainActivity.java
+++ b/app/src/main/java/com/github/yuukis/businessmap/app/MainActivity.java
@@ -74,10 +74,18 @@ public class MainActivity extends AppCompatActivity implements
 	protected void onStart() {
 		super.onStart();
 		if (mContactsList == null) {
-			mContactsList = new ArrayList<ContactsItem>();
-
-			if (hasContactsPermission() && !mTaskFragment.isRunning()) {
-				mTaskFragment.start();
+			List<ContactsItem> retained = mTaskFragment.getContactsList();
+			if (retained != null) {
+				// Activity was recreated (e.g. rotation); the retained task
+				// fragment already has the data in memory, so adopt it
+				// directly instead of re-querying contacts from scratch.
+				mContactsList = retained;
+				notifyDataSetChanged();
+			} else {
+				mContactsList = new ArrayList<ContactsItem>();
+				if (hasContactsPermission() && !mTaskFragment.isRunning()) {
+					mTaskFragment.start();
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
- `MainActivity.onSaveInstanceState()` was serializing the entire contacts list into the saved-state `Bundle`, which is transmitted via Binder IPC when the activity stops. With enough contacts this exceeds the Binder transaction size limit and crashes with `TransactionTooLargeException`.
- `ContactsTaskFragment` already retains its instance (`setRetainInstance(true)`) and disk-caches the contacts list, so restoring it via the saved-state Bundle was redundant and unsafe. Removed it; `onStart()` already reloads from the fragment's cache when `mContactsList` is null.

## Test plan
- [x] `./gradlew assembleDebug` succeeds
- [x] `./gradlew lintDebug` succeeds with no errors
- [x] Manually reproduce on a device/emulator with a large contact list: background/rotate the app and confirm no crash