### PR TITLE
Handle edge-to-edge window insets to fix top bar overlap

### DIFF
--- a/app/src/main/java/com/github/yuukis/businessmap/app/MainActivity.java
+++ b/app/src/main/java/com/github/yuukis/businessmap/app/MainActivity.java
@@ -29,7 +29,6 @@ import com.github.yuukis.businessmap.widget.GroupAdapter;
 import android.Manifest;
 import android.content.pm.PackageManager;
 import android.os.Bundle;
-import android.util.TypedValue;
 import androidx.activity.result.ActivityResultLauncher;
 import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.core.content.ContextCompat;
@@ -77,29 +76,20 @@ public class MainActivity extends AppCompatActivity implements
 	}
 
 	/**
-	 * Apps targeting Android 15 (API 35) are forced edge-to-edge, and this
-	 * app's ActionBar ends up floating over our own content instead of
-	 * reserving space above it. Rather than rely on how AppCompat/the
-	 * platform happen to position the ActionBar internally, pad our own
-	 * content root by the status bar inset plus the ActionBar's actual
-	 * height, so our content (the map, contacts list, etc.) is guaranteed to
-	 * start below it regardless.
+	 * Apps targeting Android 15 (API 35) are forced edge-to-edge. The
+	 * ActionBar already reserves its own height correctly above our content
+	 * (confirmed empirically: adding the ActionBar's height on top of the
+	 * status bar inset overshot by about one ActionBar height). All that's
+	 * actually missing is room for the status bar itself, so only pad for
+	 * that.
 	 */
 	private void applyEdgeToEdgeInsets() {
 		View root = findViewById(R.id.activity_main_root);
 		ViewCompat.setOnApplyWindowInsetsListener(root, (v, insets) -> {
 			Insets bars = insets.getInsets(WindowInsetsCompat.Type.systemBars());
-			v.setPadding(bars.left, bars.top + getActionBarHeight(), bars.right, bars.bottom);
+			v.setPadding(bars.left, bars.top, bars.right, bars.bottom);
 			return WindowInsetsCompat.CONSUMED;
 		});
-	}
-
-	private int getActionBarHeight() {
-		TypedValue value = new TypedValue();
-		if (getTheme().resolveAttribute(android.R.attr.actionBarSize, value, true)) {
-			return TypedValue.complexToDimensionPixelSize(value.data, getResources().getDisplayMetrics());
-		}
-		return 0;
 	}
 
 	@Override

--- a/app/src/main/java/com/github/yuukis/businessmap/app/MainActivity.java
+++ b/app/src/main/java/com/github/yuukis/businessmap/app/MainActivity.java
@@ -29,6 +29,7 @@ import com.github.yuukis.businessmap.widget.GroupAdapter;
 import android.Manifest;
 import android.content.pm.PackageManager;
 import android.os.Bundle;
+import android.util.TypedValue;
 import androidx.activity.result.ActivityResultLauncher;
 import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.core.content.ContextCompat;
@@ -41,6 +42,7 @@ import androidx.appcompat.app.AppCompatActivity;
 import android.view.KeyEvent;
 import android.view.Menu;
 import android.view.MenuItem;
+import android.view.View;
 import android.view.WindowManager;
 
 public class MainActivity extends AppCompatActivity implements
@@ -75,24 +77,29 @@ public class MainActivity extends AppCompatActivity implements
 	}
 
 	/**
-	 * Apps targeting Android 15 (API 35) are forced edge-to-edge: the window
-	 * content (including the legacy, non-overlay ActionBar) is laid out
-	 * behind the status/navigation bars unless we account for the system bar
-	 * insets ourselves. Pad the whole decor view so nothing is obscured.
-	 *
-	 * The insets must be consumed (not just read) here: this app's ActionBar
-	 * decor root (AppCompat's abc_screen_simple.xml) has
-	 * android:fitsSystemWindows="true", and the platform's default View
-	 * inset handling for that flag would otherwise apply the same insets a
-	 * second time as it propagates down, pushing the ActionBar to a wrong,
-	 * partially-offset position.
+	 * Apps targeting Android 15 (API 35) are forced edge-to-edge, and this
+	 * app's ActionBar ends up floating over our own content instead of
+	 * reserving space above it. Rather than rely on how AppCompat/the
+	 * platform happen to position the ActionBar internally, pad our own
+	 * content root by the status bar inset plus the ActionBar's actual
+	 * height, so our content (the map, contacts list, etc.) is guaranteed to
+	 * start below it regardless.
 	 */
 	private void applyEdgeToEdgeInsets() {
-		ViewCompat.setOnApplyWindowInsetsListener(getWindow().getDecorView(), (v, insets) -> {
+		View root = findViewById(R.id.activity_main_root);
+		ViewCompat.setOnApplyWindowInsetsListener(root, (v, insets) -> {
 			Insets bars = insets.getInsets(WindowInsetsCompat.Type.systemBars());
-			v.setPadding(bars.left, bars.top, bars.right, bars.bottom);
+			v.setPadding(bars.left, bars.top + getActionBarHeight(), bars.right, bars.bottom);
 			return WindowInsetsCompat.CONSUMED;
 		});
+	}
+
+	private int getActionBarHeight() {
+		TypedValue value = new TypedValue();
+		if (getTheme().resolveAttribute(android.R.attr.actionBarSize, value, true)) {
+			return TypedValue.complexToDimensionPixelSize(value.data, getResources().getDisplayMetrics());
+		}
+		return 0;
 	}
 
 	@Override

--- a/app/src/main/java/com/github/yuukis/businessmap/app/MainActivity.java
+++ b/app/src/main/java/com/github/yuukis/businessmap/app/MainActivity.java
@@ -79,12 +79,19 @@ public class MainActivity extends AppCompatActivity implements
 	 * content (including the legacy, non-overlay ActionBar) is laid out
 	 * behind the status/navigation bars unless we account for the system bar
 	 * insets ourselves. Pad the whole decor view so nothing is obscured.
+	 *
+	 * The insets must be consumed (not just read) here: this app's ActionBar
+	 * decor root (AppCompat's abc_screen_simple.xml) has
+	 * android:fitsSystemWindows="true", and the platform's default View
+	 * inset handling for that flag would otherwise apply the same insets a
+	 * second time as it propagates down, pushing the ActionBar to a wrong,
+	 * partially-offset position.
 	 */
 	private void applyEdgeToEdgeInsets() {
 		ViewCompat.setOnApplyWindowInsetsListener(getWindow().getDecorView(), (v, insets) -> {
 			Insets bars = insets.getInsets(WindowInsetsCompat.Type.systemBars());
 			v.setPadding(bars.left, bars.top, bars.right, bars.bottom);
-			return insets;
+			return WindowInsetsCompat.CONSUMED;
 		});
 	}
 

--- a/app/src/main/java/com/github/yuukis/businessmap/app/MainActivity.java
+++ b/app/src/main/java/com/github/yuukis/businessmap/app/MainActivity.java
@@ -32,6 +32,9 @@ import android.os.Bundle;
 import androidx.activity.result.ActivityResultLauncher;
 import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.core.content.ContextCompat;
+import androidx.core.graphics.Insets;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
 import androidx.fragment.app.FragmentManager;
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AppCompatActivity;
@@ -66,8 +69,23 @@ public class MainActivity extends AppCompatActivity implements
 		getWindow().setSoftInputMode(
 				WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_HIDDEN);
 		setContentView(R.layout.activity_main);
+		applyEdgeToEdgeInsets();
 		initialize(savedInstanceState);
 		requestMissingPermissions();
+	}
+
+	/**
+	 * Apps targeting Android 15 (API 35) are forced edge-to-edge: the window
+	 * content (including the legacy, non-overlay ActionBar) is laid out
+	 * behind the status/navigation bars unless we account for the system bar
+	 * insets ourselves. Pad the whole decor view so nothing is obscured.
+	 */
+	private void applyEdgeToEdgeInsets() {
+		ViewCompat.setOnApplyWindowInsetsListener(getWindow().getDecorView(), (v, insets) -> {
+			Insets bars = insets.getInsets(WindowInsetsCompat.Type.systemBars());
+			v.setPadding(bars.left, bars.top, bars.right, bars.bottom);
+			return insets;
+		});
 	}
 
 	@Override

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/activity_main_root"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:context="com.github.yuukis.businessmap.app.MainActivity" >


### PR DESCRIPTION
## Summary
- Apps targeting Android 15 (API 35) can no longer opt out of edge-to-edge: window content (including this app's legacy non-overlay ActionBar) is now laid out behind the status/navigation bars regardless of theme.
- Added a `WindowInsetsCompat` listener on the decor view in `MainActivity` that pads it by the system bars insets, restoring the previous (non-overlapping) layout for the ActionBar and all content.

## Test plan
- [x] `./gradlew assembleDebug` succeeds
- [x] `./gradlew lintDebug` succeeds with no errors
- [x] Manually verify on an Android 15+ device/emulator that the ActionBar (group spinner) no longer overlaps the status bar, and bottom content isn't obscured by the navigation bar