### PR TITLE
[段階1] Material Components 導入 + ActionBar(スピナーナビゲーション)の廃止

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -57,5 +57,6 @@ configurations.all {
 dependencies {
     implementation("androidx.appcompat:appcompat:1.7.0")
     implementation("androidx.fragment:fragment:1.8.5")
+    implementation("com.google.android.material:material:1.12.0")
     implementation("com.google.android.gms:play-services-maps:19.0.0")
 }

--- a/app/src/main/java/com/github/yuukis/businessmap/app/AboutDialogFragment.kt
+++ b/app/src/main/java/com/github/yuukis/businessmap/app/AboutDialogFragment.kt
@@ -17,7 +17,6 @@
  */
 package com.github.yuukis.businessmap.app
 
-import android.app.AlertDialog
 import android.app.Dialog
 import android.content.pm.PackageManager
 import android.content.pm.PackageManager.NameNotFoundException
@@ -26,6 +25,7 @@ import android.view.View
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.DialogFragment
 import com.github.yuukis.businessmap.R
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 
 class AboutDialogFragment : DialogFragment(), View.OnClickListener {
 
@@ -36,7 +36,7 @@ class AboutDialogFragment : DialogFragment(), View.OnClickListener {
         view.findViewById<android.widget.TextView>(R.id.textview_about_version).text = getVersion()
         view.findViewById<View>(R.id.textview_license).setOnClickListener(this)
 
-        return AlertDialog.Builder(activity)
+        return MaterialAlertDialogBuilder(activity)
             .setTitle(R.string.action_about)
             .setView(view)
             .setPositiveButton(android.R.string.ok, null)

--- a/app/src/main/java/com/github/yuukis/businessmap/app/ContactsActionFragment.kt
+++ b/app/src/main/java/com/github/yuukis/businessmap/app/ContactsActionFragment.kt
@@ -19,6 +19,7 @@ package com.github.yuukis.businessmap.app
 
 import android.app.Dialog
 import android.content.Context
+import android.content.res.ColorStateList
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -33,6 +34,8 @@ import androidx.fragment.app.FragmentActivity
 import com.github.yuukis.businessmap.R
 import com.github.yuukis.businessmap.model.ContactsItem
 import com.github.yuukis.businessmap.util.ActionUtils
+import com.google.android.material.R as MaterialR
+import com.google.android.material.color.MaterialColors
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 
 class ContactsActionFragment : DialogFragment(), AdapterView.OnItemClickListener {
@@ -101,6 +104,8 @@ class ContactsActionFragment : DialogFragment(), AdapterView.OnItemClickListener
             if (data != null) {
                 holder.textView.setText(data.titleId)
                 holder.imageView.setImageResource(data.iconId)
+                holder.imageView.imageTintList =
+                    ColorStateList.valueOf(MaterialColors.getColor(holder.imageView, MaterialR.attr.colorOnSurface))
             }
 
             return view

--- a/app/src/main/java/com/github/yuukis/businessmap/app/ContactsActionFragment.kt
+++ b/app/src/main/java/com/github/yuukis/businessmap/app/ContactsActionFragment.kt
@@ -17,7 +17,6 @@
  */
 package com.github.yuukis.businessmap.app
 
-import android.app.AlertDialog
 import android.app.Dialog
 import android.content.Context
 import android.graphics.Color
@@ -35,6 +34,7 @@ import androidx.fragment.app.FragmentActivity
 import com.github.yuukis.businessmap.R
 import com.github.yuukis.businessmap.model.ContactsItem
 import com.github.yuukis.businessmap.util.ActionUtils
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 
 class ContactsActionFragment : DialogFragment(), AdapterView.OnItemClickListener {
 
@@ -52,7 +52,7 @@ class ContactsActionFragment : DialogFragment(), AdapterView.OnItemClickListener
         gridView.setBackgroundColor(Color.WHITE)
         val title = contact?.name
 
-        return AlertDialog.Builder(activity)
+        return MaterialAlertDialogBuilder(requireActivity())
             .setTitle(title)
             .setView(gridView)
             .setNegativeButton(android.R.string.cancel, null)

--- a/app/src/main/java/com/github/yuukis/businessmap/app/ContactsActionFragment.kt
+++ b/app/src/main/java/com/github/yuukis/businessmap/app/ContactsActionFragment.kt
@@ -33,8 +33,6 @@ import androidx.fragment.app.FragmentActivity
 import com.github.yuukis.businessmap.R
 import com.github.yuukis.businessmap.model.ContactsItem
 import com.github.yuukis.businessmap.util.ActionUtils
-import com.google.android.material.R as MaterialR
-import com.google.android.material.color.MaterialColors
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 
 class ContactsActionFragment : DialogFragment(), AdapterView.OnItemClickListener {
@@ -50,7 +48,6 @@ class ContactsActionFragment : DialogFragment(), AdapterView.OnItemClickListener
         gridView.numColumns = columns
         gridView.adapter = adapter
         gridView.onItemClickListener = this
-        gridView.setBackgroundColor(MaterialColors.getColor(gridView, MaterialR.attr.colorSurface))
         val title = contact?.name
 
         return MaterialAlertDialogBuilder(requireActivity())

--- a/app/src/main/java/com/github/yuukis/businessmap/app/ContactsActionFragment.kt
+++ b/app/src/main/java/com/github/yuukis/businessmap/app/ContactsActionFragment.kt
@@ -19,7 +19,6 @@ package com.github.yuukis.businessmap.app
 
 import android.app.Dialog
 import android.content.Context
-import android.graphics.Color
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -34,6 +33,8 @@ import androidx.fragment.app.FragmentActivity
 import com.github.yuukis.businessmap.R
 import com.github.yuukis.businessmap.model.ContactsItem
 import com.github.yuukis.businessmap.util.ActionUtils
+import com.google.android.material.R as MaterialR
+import com.google.android.material.color.MaterialColors
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 
 class ContactsActionFragment : DialogFragment(), AdapterView.OnItemClickListener {
@@ -49,7 +50,7 @@ class ContactsActionFragment : DialogFragment(), AdapterView.OnItemClickListener
         gridView.numColumns = columns
         gridView.adapter = adapter
         gridView.onItemClickListener = this
-        gridView.setBackgroundColor(Color.WHITE)
+        gridView.setBackgroundColor(MaterialColors.getColor(gridView, MaterialR.attr.colorSurface))
         val title = contact?.name
 
         return MaterialAlertDialogBuilder(requireActivity())

--- a/app/src/main/java/com/github/yuukis/businessmap/app/ContactsGroupDialogFragment.kt
+++ b/app/src/main/java/com/github/yuukis/businessmap/app/ContactsGroupDialogFragment.kt
@@ -21,6 +21,7 @@ import android.app.Dialog
 import android.content.Context
 import android.content.DialogInterface
 import android.os.Bundle
+import android.widget.ArrayAdapter
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.FragmentActivity
 import com.github.yuukis.businessmap.R
@@ -47,9 +48,10 @@ class ContactsGroupDialogFragment : DialogFragment(), DialogInterface.OnClickLis
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         val items = getContactsGroupTitleArray()
+        val adapter = ArrayAdapter(requireActivity(), R.layout.dialog_list_item, android.R.id.text1, items)
         return MaterialAlertDialogBuilder(requireActivity())
             .setTitle(R.string.action_select_group)
-            .setItems(items, this)
+            .setAdapter(adapter, this)
             .setNegativeButton(android.R.string.cancel, this)
             .create()
     }

--- a/app/src/main/java/com/github/yuukis/businessmap/app/ContactsGroupDialogFragment.kt
+++ b/app/src/main/java/com/github/yuukis/businessmap/app/ContactsGroupDialogFragment.kt
@@ -17,7 +17,6 @@
  */
 package com.github.yuukis.businessmap.app
 
-import android.app.AlertDialog
 import android.app.Dialog
 import android.content.Context
 import android.content.DialogInterface
@@ -27,6 +26,7 @@ import androidx.fragment.app.FragmentActivity
 import com.github.yuukis.businessmap.R
 import com.github.yuukis.businessmap.model.ContactsGroup
 import com.github.yuukis.businessmap.util.ContactUtils
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 
 class ContactsGroupDialogFragment : DialogFragment(), DialogInterface.OnClickListener {
 
@@ -47,7 +47,7 @@ class ContactsGroupDialogFragment : DialogFragment(), DialogInterface.OnClickLis
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         val items = getContactsGroupTitleArray()
-        return AlertDialog.Builder(activity)
+        return MaterialAlertDialogBuilder(requireActivity())
             .setTitle(R.string.action_select_group)
             .setItems(items, this)
             .setNegativeButton(android.R.string.cancel, this)

--- a/app/src/main/java/com/github/yuukis/businessmap/app/ContactsItemsDialogFragment.kt
+++ b/app/src/main/java/com/github/yuukis/businessmap/app/ContactsItemsDialogFragment.kt
@@ -17,7 +17,6 @@
  */
 package com.github.yuukis.businessmap.app
 
-import android.app.AlertDialog
 import android.app.Dialog
 import android.content.Context
 import android.content.DialogInterface
@@ -26,6 +25,7 @@ import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.FragmentActivity
 import com.github.yuukis.businessmap.R
 import com.github.yuukis.businessmap.model.ContactsItem
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import java.io.Serializable
 
 class ContactsItemsDialogFragment : DialogFragment(), DialogInterface.OnClickListener {
@@ -51,7 +51,7 @@ class ContactsItemsDialogFragment : DialogFragment(), DialogInterface.OnClickLis
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         val items = getContactsItemsTitleArray()
-        return AlertDialog.Builder(activity)
+        return MaterialAlertDialogBuilder(requireActivity())
             .setTitle(R.string.action_select_contacts)
             .setItems(items, this)
             .create()

--- a/app/src/main/java/com/github/yuukis/businessmap/app/ContactsItemsDialogFragment.kt
+++ b/app/src/main/java/com/github/yuukis/businessmap/app/ContactsItemsDialogFragment.kt
@@ -21,6 +21,7 @@ import android.app.Dialog
 import android.content.Context
 import android.content.DialogInterface
 import android.os.Bundle
+import android.widget.ArrayAdapter
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.FragmentActivity
 import com.github.yuukis.businessmap.R
@@ -51,9 +52,10 @@ class ContactsItemsDialogFragment : DialogFragment(), DialogInterface.OnClickLis
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         val items = getContactsItemsTitleArray()
+        val adapter = ArrayAdapter(requireActivity(), R.layout.dialog_list_item, android.R.id.text1, items)
         return MaterialAlertDialogBuilder(requireActivity())
             .setTitle(R.string.action_select_contacts)
-            .setItems(items, this)
+            .setAdapter(adapter, this)
             .create()
     }
 

--- a/app/src/main/java/com/github/yuukis/businessmap/app/ContactsListFragment.kt
+++ b/app/src/main/java/com/github/yuukis/businessmap/app/ContactsListFragment.kt
@@ -17,7 +17,6 @@
  */
 package com.github.yuukis.businessmap.app
 
-import android.app.AlertDialog
 import android.os.Bundle
 import android.text.TextUtils
 import android.view.LayoutInflater
@@ -37,6 +36,7 @@ import com.github.yuukis.businessmap.R
 import com.github.yuukis.businessmap.model.ContactsItem
 import com.github.yuukis.businessmap.util.ActionUtils
 import com.github.yuukis.businessmap.util.StringJUtils
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.slidinglayer.SlidingLayer
 
 class ContactsListFragment : ListFragment(), SearchView.OnQueryTextListener {
@@ -94,7 +94,7 @@ class ContactsListFragment : ListFragment(), SearchView.OnQueryTextListener {
         val context = requireActivity()
         val title = contact.name
         val items = arrayOf(getString(R.string.action_contacts_detail))
-        AlertDialog.Builder(requireActivity()).setTitle(title)
+        MaterialAlertDialogBuilder(requireActivity()).setTitle(title)
             .setItems(items) { _, which ->
                 when (which) {
                     0 -> ActionUtils.doShowContact(context, contact)

--- a/app/src/main/java/com/github/yuukis/businessmap/app/ContactsMapFragment.kt
+++ b/app/src/main/java/com/github/yuukis/businessmap/app/ContactsMapFragment.kt
@@ -250,8 +250,8 @@ class ContactsMapFragment : SupportMapFragment(), GoogleMap.OnInfoWindowClickLis
         infoButton = button
         val listener = object : OnInfoWindowElemTouchListener(
             button,
-            resources.getDrawable(R.drawable.infowindow_button_normal),
-            resources.getDrawable(R.drawable.infowindow_button_pressed)
+            requireNotNull(ContextCompat.getDrawable(activity, R.drawable.infowindow_button_normal)),
+            requireNotNull(ContextCompat.getDrawable(activity, R.drawable.infowindow_button_pressed))
         ) {
             override fun onClickConfirmed(v: View, marker: Marker) {
                 val position = marker.position

--- a/app/src/main/java/com/github/yuukis/businessmap/app/ContactsTaskFragment.kt
+++ b/app/src/main/java/com/github/yuukis/businessmap/app/ContactsTaskFragment.kt
@@ -17,7 +17,6 @@
  */
 package com.github.yuukis.businessmap.app
 
-import android.app.AlertDialog
 import android.content.Context
 import android.database.Cursor
 import android.os.Bundle
@@ -42,6 +41,7 @@ import com.github.yuukis.businessmap.util.CursorJoinerWithIntKey
 import com.github.yuukis.businessmap.util.GeocoderUtils
 import com.github.yuukis.businessmap.util.SerializationException
 import com.github.yuukis.businessmap.util.SerializationUtils
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import org.json.JSONException
 import java.io.FileNotFoundException
 import java.io.IOException
@@ -169,7 +169,7 @@ class ContactsTaskFragment : Fragment() {
     private fun showError(title: String, message: String) {
         val currentActivity = activity ?: return
         Handler(Looper.getMainLooper()).post {
-            AlertDialog.Builder(currentActivity)
+            MaterialAlertDialogBuilder(currentActivity)
                 .setTitle(title)
                 .setMessage(message)
                 .setPositiveButton(android.R.string.ok, null)

--- a/app/src/main/java/com/github/yuukis/businessmap/app/LicenseDialogFragment.kt
+++ b/app/src/main/java/com/github/yuukis/businessmap/app/LicenseDialogFragment.kt
@@ -66,11 +66,14 @@ class LicenseDialogFragment : DialogFragment() {
         }
         val webView = WebView(requireActivity())
         webView.loadData(html, "text/html", "utf-8")
-        ViewCompat.setOnApplyWindowInsetsListener(webView) { v, insets ->
-            val bars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
-            v.setPadding(bars.left, bars.top, bars.right, bars.bottom)
-            WindowInsetsCompat.CONSUMED
-        }
+        // This dialog has its own Window, separate from the host Activity's,
+        // and its insets dispatch is unreliable in practice. The host
+        // Activity's decor view already has correct, up-to-date system bar
+        // insets (edge-to-edge is confirmed working there), so borrow those
+        // directly instead of depending on the dialog window's own dispatch.
+        ViewCompat.getRootWindowInsets(requireActivity().window.decorView)
+            ?.getInsets(WindowInsetsCompat.Type.systemBars())
+            ?.let { bars -> webView.setPadding(bars.left, bars.top, bars.right, bars.bottom) }
         return webView
     }
 

--- a/app/src/main/java/com/github/yuukis/businessmap/app/LicenseDialogFragment.kt
+++ b/app/src/main/java/com/github/yuukis/businessmap/app/LicenseDialogFragment.kt
@@ -24,6 +24,9 @@ import android.view.View
 import android.view.ViewGroup
 import android.view.WindowManager
 import android.webkit.WebView
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsCompat
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.FragmentActivity
 import com.github.yuukis.businessmap.R
@@ -41,7 +44,10 @@ class LicenseDialogFragment : DialogFragment() {
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         val dialog = super.onCreateDialog(savedInstanceState)
-        dialog.window?.setLayout(WindowManager.LayoutParams.MATCH_PARENT, WindowManager.LayoutParams.MATCH_PARENT)
+        dialog.window?.let { window ->
+            window.setLayout(WindowManager.LayoutParams.MATCH_PARENT, WindowManager.LayoutParams.MATCH_PARENT)
+            WindowCompat.setDecorFitsSystemWindows(window, false)
+        }
         return dialog
     }
 
@@ -63,7 +69,27 @@ class LicenseDialogFragment : DialogFragment() {
 
         val webView = view.findViewById<WebView>(R.id.webview_license)
         webView.loadData(html, "text/html", "utf-8")
+
+        applyEdgeToEdgeInsets(view, toolbar)
         return view
+    }
+
+    /**
+     * Same technique as MainActivity: the toolbar's fixed height must grow
+     * by the status bar inset (not just gain top padding within a fixed
+     * height), otherwise its title gets squeezed and clipped.
+     */
+    private fun applyEdgeToEdgeInsets(root: View, toolbar: View) {
+        val toolbarContentHeight = toolbar.layoutParams.height
+        ViewCompat.setOnApplyWindowInsetsListener(root) { v, insets ->
+            val bars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
+            toolbar.layoutParams = toolbar.layoutParams.apply {
+                height = toolbarContentHeight + bars.top
+            }
+            toolbar.setPadding(toolbar.paddingLeft, bars.top, toolbar.paddingRight, toolbar.paddingBottom)
+            v.setPadding(bars.left, 0, bars.right, bars.bottom)
+            WindowInsetsCompat.CONSUMED
+        }
     }
 
     companion object {

--- a/app/src/main/java/com/github/yuukis/businessmap/app/LicenseDialogFragment.kt
+++ b/app/src/main/java/com/github/yuukis/businessmap/app/LicenseDialogFragment.kt
@@ -17,10 +17,12 @@
  */
 package com.github.yuukis.businessmap.app
 
+import android.app.Dialog
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.view.WindowManager
 import android.webkit.WebView
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowCompat
@@ -39,10 +41,17 @@ class LicenseDialogFragment : DialogFragment() {
         setStyle(STYLE_NO_TITLE, R.style.AppTheme)
     }
 
-    override fun onStart() {
-        super.onStart()
-        val window = dialog?.window ?: return
-        WindowCompat.setDecorFitsSystemWindows(window, false)
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        val dialog = super.onCreateDialog(savedInstanceState)
+        // The window must be sized to the full screen and opted out of the
+        // default inset-fitting *before* the WebView is attached, otherwise
+        // the first inset dispatch still reserves system bar space and the
+        // listener below never gets a chance to pad around it.
+        dialog.window?.let { window ->
+            window.setLayout(WindowManager.LayoutParams.MATCH_PARENT, WindowManager.LayoutParams.MATCH_PARENT)
+            WindowCompat.setDecorFitsSystemWindows(window, false)
+        }
+        return dialog
     }
 
     override fun onCreateView(

--- a/app/src/main/java/com/github/yuukis/businessmap/app/LicenseDialogFragment.kt
+++ b/app/src/main/java/com/github/yuukis/businessmap/app/LicenseDialogFragment.kt
@@ -22,6 +22,9 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.webkit.WebView
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsCompat
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.FragmentActivity
 import com.github.yuukis.businessmap.R
@@ -36,6 +39,12 @@ class LicenseDialogFragment : DialogFragment() {
         setStyle(STYLE_NO_TITLE, R.style.AppTheme)
     }
 
+    override fun onStart() {
+        super.onStart()
+        val window = dialog?.window ?: return
+        WindowCompat.setDecorFitsSystemWindows(window, false)
+    }
+
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
@@ -48,6 +57,11 @@ class LicenseDialogFragment : DialogFragment() {
         }
         val webView = WebView(requireActivity())
         webView.loadData(html, "text/html", "utf-8")
+        ViewCompat.setOnApplyWindowInsetsListener(webView) { v, insets ->
+            val bars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
+            v.setPadding(bars.left, bars.top, bars.right, bars.bottom)
+            WindowInsetsCompat.CONSUMED
+        }
         return webView
     }
 

--- a/app/src/main/java/com/github/yuukis/businessmap/app/LicenseDialogFragment.kt
+++ b/app/src/main/java/com/github/yuukis/businessmap/app/LicenseDialogFragment.kt
@@ -24,13 +24,11 @@ import android.view.View
 import android.view.ViewGroup
 import android.view.WindowManager
 import android.webkit.WebView
-import androidx.core.view.ViewCompat
-import androidx.core.view.WindowCompat
-import androidx.core.view.WindowInsetsCompat
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.FragmentActivity
 import com.github.yuukis.businessmap.R
 import com.github.yuukis.businessmap.util.AssetUtils
+import com.google.android.material.appbar.MaterialToolbar
 import java.io.UnsupportedEncodingException
 import java.net.URLEncoder
 
@@ -43,14 +41,7 @@ class LicenseDialogFragment : DialogFragment() {
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         val dialog = super.onCreateDialog(savedInstanceState)
-        // The window must be sized to the full screen and opted out of the
-        // default inset-fitting *before* the WebView is attached, otherwise
-        // the first inset dispatch still reserves system bar space and the
-        // listener below never gets a chance to pad around it.
-        dialog.window?.let { window ->
-            window.setLayout(WindowManager.LayoutParams.MATCH_PARENT, WindowManager.LayoutParams.MATCH_PARENT)
-            WindowCompat.setDecorFitsSystemWindows(window, false)
-        }
+        dialog.window?.setLayout(WindowManager.LayoutParams.MATCH_PARENT, WindowManager.LayoutParams.MATCH_PARENT)
         return dialog
     }
 
@@ -64,17 +55,15 @@ class LicenseDialogFragment : DialogFragment() {
             html = URLEncoder.encode(html, "utf-8").replace("\\+".toRegex(), "%20")
         } catch (e: UnsupportedEncodingException) {
         }
-        val webView = WebView(requireActivity())
+
+        val view = inflater.inflate(R.layout.dialog_license, container, false)
+        val toolbar = view.findViewById<MaterialToolbar>(R.id.toolbar_license)
+        toolbar.setNavigationIcon(android.R.drawable.ic_menu_close_clear_cancel)
+        toolbar.setNavigationOnClickListener { dismiss() }
+
+        val webView = view.findViewById<WebView>(R.id.webview_license)
         webView.loadData(html, "text/html", "utf-8")
-        // This dialog has its own Window, separate from the host Activity's,
-        // and its insets dispatch is unreliable in practice. The host
-        // Activity's decor view already has correct, up-to-date system bar
-        // insets (edge-to-edge is confirmed working there), so borrow those
-        // directly instead of depending on the dialog window's own dispatch.
-        ViewCompat.getRootWindowInsets(requireActivity().window.decorView)
-            ?.getInsets(WindowInsetsCompat.Type.systemBars())
-            ?.let { bars -> webView.setPadding(bars.left, bars.top, bars.right, bars.bottom) }
-        return webView
+        return view
     }
 
     companion object {

--- a/app/src/main/java/com/github/yuukis/businessmap/app/LicenseDialogFragment.kt
+++ b/app/src/main/java/com/github/yuukis/businessmap/app/LicenseDialogFragment.kt
@@ -64,7 +64,7 @@ class LicenseDialogFragment : DialogFragment() {
 
         val view = inflater.inflate(R.layout.dialog_license, container, false)
         val toolbar = view.findViewById<MaterialToolbar>(R.id.toolbar_license)
-        toolbar.setNavigationIcon(android.R.drawable.ic_menu_close_clear_cancel)
+        toolbar.setNavigationIcon(R.drawable.ic_close)
         toolbar.setNavigationOnClickListener { dismiss() }
 
         val webView = view.findViewById<WebView>(R.id.webview_license)

--- a/app/src/main/java/com/github/yuukis/businessmap/app/MainActivity.kt
+++ b/app/src/main/java/com/github/yuukis/businessmap/app/MainActivity.kt
@@ -68,14 +68,21 @@ class MainActivity : AppCompatActivity(), AdapterView.OnItemSelectedListener,
     /**
      * Apps targeting Android 15 (API 35) are forced edge-to-edge. The
      * MaterialToolbar now lives inside our own layout rather than being
-     * reserved by the system, so it must absorb the status bar inset itself
-     * via top padding; the root only needs padding for the remaining sides.
+     * reserved by the system, so it must absorb the status bar inset itself.
+     * Padding alone would squeeze its fixed-height content (the group
+     * spinner) into a shorter area and clip it, so the inset is added on top
+     * of the toolbar's original height instead, with padding only offsetting
+     * the content down into that extra space.
      */
     private fun applyEdgeToEdgeInsets() {
         val root = findViewById<View>(R.id.activity_main_root)
         val toolbar = findViewById<View>(R.id.toolbar)
+        val toolbarContentHeight = toolbar.layoutParams.height
         ViewCompat.setOnApplyWindowInsetsListener(root) { v, insets ->
             val bars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
+            toolbar.layoutParams = toolbar.layoutParams.apply {
+                height = toolbarContentHeight + bars.top
+            }
             toolbar.setPadding(toolbar.paddingLeft, bars.top, toolbar.paddingRight, toolbar.paddingBottom)
             v.setPadding(bars.left, 0, bars.right, bars.bottom)
             WindowInsetsCompat.CONSUMED

--- a/app/src/main/java/com/github/yuukis/businessmap/app/MainActivity.kt
+++ b/app/src/main/java/com/github/yuukis/businessmap/app/MainActivity.kt
@@ -215,6 +215,7 @@ class MainActivity : AppCompatActivity(), AdapterView.OnItemSelectedListener,
             ArrayList()
         }
 
+        currentGroupContactsList = ArrayList()
         groupAdapter = GroupAdapter(this, groupList)
         val toolbar = findViewById<MaterialToolbar>(R.id.toolbar)
         setSupportActionBar(toolbar)
@@ -239,7 +240,6 @@ class MainActivity : AppCompatActivity(), AdapterView.OnItemSelectedListener,
             }
         }
         groupSpinner.setSelection(navigationIndex)
-        currentGroupContactsList = ArrayList()
     }
 
     private fun notifyDataSetChanged() {

--- a/app/src/main/java/com/github/yuukis/businessmap/app/MainActivity.kt
+++ b/app/src/main/java/com/github/yuukis/businessmap/app/MainActivity.kt
@@ -23,9 +23,11 @@ import android.os.Bundle
 import android.view.KeyEvent
 import android.view.Menu
 import android.view.MenuItem
+import android.view.View
 import android.view.WindowManager
+import android.widget.AdapterView
+import android.widget.Spinner
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.appcompat.app.ActionBar
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
 import androidx.core.view.ViewCompat
@@ -35,8 +37,9 @@ import com.github.yuukis.businessmap.model.ContactsGroup
 import com.github.yuukis.businessmap.model.ContactsItem
 import com.github.yuukis.businessmap.util.ContactUtils
 import com.github.yuukis.businessmap.widget.GroupAdapter
+import com.google.android.material.appbar.MaterialToolbar
 
-class MainActivity : AppCompatActivity(), ActionBar.OnNavigationListener,
+class MainActivity : AppCompatActivity(), AdapterView.OnItemSelectedListener,
     ContactsTaskFragment.TaskCallback, ProgressDialogFragment.ProgressDialogFragmentListener,
     ContactsItemsDialogFragment.OnSelectListener {
 
@@ -47,6 +50,7 @@ class MainActivity : AppCompatActivity(), ActionBar.OnNavigationListener,
     private lateinit var listFragment: ContactsListFragment
     private lateinit var taskFragment: ContactsTaskFragment
     private lateinit var groupAdapter: GroupAdapter
+    private lateinit var groupSpinner: Spinner
     private val permissionLauncher =
         registerForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) {
             onPermissionsResult()
@@ -63,17 +67,17 @@ class MainActivity : AppCompatActivity(), ActionBar.OnNavigationListener,
 
     /**
      * Apps targeting Android 15 (API 35) are forced edge-to-edge. The
-     * ActionBar already reserves its own height correctly above our content
-     * (confirmed empirically: adding the ActionBar's height on top of the
-     * status bar inset overshot by about one ActionBar height). All that's
-     * actually missing is room for the status bar itself, so only pad for
-     * that.
+     * MaterialToolbar now lives inside our own layout rather than being
+     * reserved by the system, so it must absorb the status bar inset itself
+     * via top padding; the root only needs padding for the remaining sides.
      */
     private fun applyEdgeToEdgeInsets() {
-        val root = findViewById<android.view.View>(R.id.activity_main_root)
+        val root = findViewById<View>(R.id.activity_main_root)
+        val toolbar = findViewById<View>(R.id.toolbar)
         ViewCompat.setOnApplyWindowInsetsListener(root) { v, insets ->
             val bars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
-            v.setPadding(bars.left, bars.top, bars.right, bars.bottom)
+            toolbar.setPadding(toolbar.paddingLeft, bars.top, toolbar.paddingRight, toolbar.paddingBottom)
+            v.setPadding(bars.left, 0, bars.right, bars.bottom)
             WindowInsetsCompat.CONSUMED
         }
     }
@@ -124,9 +128,8 @@ class MainActivity : AppCompatActivity(), ActionBar.OnNavigationListener,
             groupList.clear()
             groupList.addAll(ContactUtils.getContactsGroupList(this))
             groupAdapter.notifyDataSetChanged()
-            val actionBar = supportActionBar
-            if (actionBar != null && actionBar.selectedNavigationIndex < 0) {
-                actionBar.setSelectedNavigationItem(0)
+            if (groupSpinner.selectedItemPosition < 0) {
+                groupSpinner.setSelection(0)
             }
             taskFragment.start()
         }
@@ -146,14 +149,15 @@ class MainActivity : AppCompatActivity(), ActionBar.OnNavigationListener,
     }
 
     override fun onSaveInstanceState(outState: Bundle) {
-        val navigationIndex = supportActionBar?.selectedNavigationIndex ?: 0
-        outState.putInt(KEY_NAVIGATION_INDEX, navigationIndex)
+        outState.putInt(KEY_NAVIGATION_INDEX, groupSpinner.selectedItemPosition)
         super.onSaveInstanceState(outState)
     }
 
-    override fun onNavigationItemSelected(itemPosition: Int, itemId: Long): Boolean {
+    override fun onItemSelected(parent: AdapterView<*>?, view: View?, position: Int, id: Long) {
         notifyDataSetChanged()
-        return true
+    }
+
+    override fun onNothingSelected(parent: AdapterView<*>?) {
     }
 
     override fun onContactsLoaded(contactsList: List<ContactsItem>?) {
@@ -205,11 +209,12 @@ class MainActivity : AppCompatActivity(), ActionBar.OnNavigationListener,
         }
 
         groupAdapter = GroupAdapter(this, groupList)
-        val actionBar = supportActionBar
-        requireNotNull(actionBar)
-        actionBar.setDisplayShowTitleEnabled(false)
-        actionBar.navigationMode = ActionBar.NAVIGATION_MODE_LIST
-        actionBar.setListNavigationCallbacks(groupAdapter, this)
+        val toolbar = findViewById<MaterialToolbar>(R.id.toolbar)
+        setSupportActionBar(toolbar)
+        supportActionBar?.setDisplayShowTitleEnabled(false)
+        groupSpinner = findViewById(R.id.spinner_group)
+        groupSpinner.adapter = groupAdapter
+        groupSpinner.onItemSelectedListener = this
 
         var navigationIndex = 0
         if (savedInstanceState != null) {
@@ -226,13 +231,12 @@ class MainActivity : AppCompatActivity(), ActionBar.OnNavigationListener,
                 }
             }
         }
-        actionBar.setSelectedNavigationItem(navigationIndex)
+        groupSpinner.setSelection(navigationIndex)
         currentGroupContactsList = ArrayList()
     }
 
     private fun notifyDataSetChanged() {
-        val actionBar = supportActionBar ?: return
-        val index = actionBar.selectedNavigationIndex
+        val index = groupSpinner.selectedItemPosition
         if (index < 0 || index >= groupList.size) {
             return
         }

--- a/app/src/main/java/com/github/yuukis/businessmap/app/ProgressDialogFragment.kt
+++ b/app/src/main/java/com/github/yuukis/businessmap/app/ProgressDialogFragment.kt
@@ -18,16 +18,21 @@
 package com.github.yuukis.businessmap.app
 
 import android.app.Dialog
-import android.app.ProgressDialog
 import android.content.DialogInterface
 import android.os.Bundle
+import android.widget.TextView
 import androidx.fragment.app.DialogFragment
+import com.github.yuukis.businessmap.R
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import com.google.android.material.progressindicator.LinearProgressIndicator
 
 class ProgressDialogFragment : DialogFragment() {
 
     interface ProgressDialogFragmentListener {
         fun onProgressCancelled()
     }
+
+    private var progressIndicator: LinearProgressIndicator? = null
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         val args = requireArguments()
@@ -36,21 +41,23 @@ class ProgressDialogFragment : DialogFragment() {
 
         val title = args.getString(TITLE)
         val message = args.getString(MESSAGE)
-        val dialog = ProgressDialog(activity)
-        dialog.setTitle(title)
-        dialog.setMessage(message)
-        dialog.isIndeterminate = false
+        val view = layoutInflater.inflate(R.layout.dialog_progress, null)
+        view.findViewById<TextView>(R.id.textview_progress_message).text = message
+        progressIndicator = view.findViewById<LinearProgressIndicator>(R.id.progress_indicator).apply {
+            isIndeterminate = false
+            max = args.getInt(MAX)
+        }
+
+        val dialog = MaterialAlertDialogBuilder(requireActivity())
+            .setTitle(title)
+            .setView(view)
+            .create()
         dialog.setCanceledOnTouchOutside(false)
-
-        dialog.setProgressStyle(ProgressDialog.STYLE_HORIZONTAL)
-        dialog.max = args.getInt(MAX)
-
         return dialog
     }
 
     fun updateProgress(value: Int) {
-        val dialog = dialog as? ProgressDialog
-        dialog?.progress = value
+        progressIndicator?.setProgressCompat(value, true)
     }
 
     override fun onCancel(dialog: DialogInterface) {

--- a/app/src/main/res/drawable/ic_close.xml
+++ b/app/src/main/res/drawable/ic_close.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24" >
+
+    <path
+        android:fillColor="?attr/colorOnSurface"
+        android:pathData="M19,6.41L17.59,5 12,10.59 6.41,5 5,6.41 10.59,12 5,17.59 6.41,19 12,13.41 17.59,19 19,17.59 13.41,12z" />
+
+</vector>

--- a/app/src/main/res/drawable/ic_info.xml
+++ b/app/src/main/res/drawable/ic_info.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24" >
+
+    <path
+        android:fillColor="?attr/colorOnSurface"
+        android:pathData="M12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2zM12,20c-4.41,0 -8,-3.59 -8,-8s3.59,-8 8,-8 8,3.59 8,8 -3.59,8 -8,8zM11,7h2v2h-2zM11,11h2v6h-2z" />
+
+</vector>

--- a/app/src/main/res/drawable/infowindow_button_normal.xml
+++ b/app/src/main/res/drawable/infowindow_button_normal.xml
@@ -8,7 +8,7 @@
         android:right="0dp"
         android:top="0dp" />
 
-    <corners android:radius="12dp" />
+    <corners android:radius="16dp" />
 
     <solid android:color="?attr/colorPrimary" />
 

--- a/app/src/main/res/drawable/infowindow_button_normal.xml
+++ b/app/src/main/res/drawable/infowindow_button_normal.xml
@@ -8,10 +8,8 @@
         android:right="0dp"
         android:top="0dp" />
 
-    <stroke
-        android:width="1dp"
-        android:color="#ccc" />
+    <corners android:radius="12dp" />
 
-    <solid android:color="#ddd" />
+    <solid android:color="?attr/colorSecondaryContainer" />
 
 </shape>

--- a/app/src/main/res/drawable/infowindow_button_normal.xml
+++ b/app/src/main/res/drawable/infowindow_button_normal.xml
@@ -10,6 +10,6 @@
 
     <corners android:radius="12dp" />
 
-    <solid android:color="?attr/colorSecondaryContainer" />
+    <solid android:color="?attr/colorPrimary" />
 
 </shape>

--- a/app/src/main/res/drawable/infowindow_button_pressed.xml
+++ b/app/src/main/res/drawable/infowindow_button_pressed.xml
@@ -10,6 +10,6 @@
 
     <corners android:radius="12dp" />
 
-    <solid android:color="?attr/colorPrimary" />
+    <solid android:color="?attr/colorPrimaryContainer" />
 
 </shape>

--- a/app/src/main/res/drawable/infowindow_button_pressed.xml
+++ b/app/src/main/res/drawable/infowindow_button_pressed.xml
@@ -8,10 +8,8 @@
         android:right="0dp"
         android:top="0dp" />
 
-    <stroke
-        android:width="1dp"
-        android:color="#ff33b5e5" />
+    <corners android:radius="12dp" />
 
-    <solid android:color="#ff00ddff" />
+    <solid android:color="?attr/colorPrimary" />
 
 </shape>

--- a/app/src/main/res/drawable/infowindow_button_pressed.xml
+++ b/app/src/main/res/drawable/infowindow_button_pressed.xml
@@ -10,6 +10,6 @@
 
     <corners android:radius="16dp" />
 
-    <solid android:color="?attr/colorPrimaryContainer" />
+    <solid android:color="?attr/colorSecondary" />
 
 </shape>

--- a/app/src/main/res/drawable/infowindow_button_pressed.xml
+++ b/app/src/main/res/drawable/infowindow_button_pressed.xml
@@ -8,7 +8,7 @@
         android:right="0dp"
         android:top="0dp" />
 
-    <corners android:radius="12dp" />
+    <corners android:radius="16dp" />
 
     <solid android:color="?attr/colorPrimaryContainer" />
 

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -6,10 +6,25 @@
     android:layout_height="match_parent"
     tools:context="com.github.yuukis.businessmap.app.MainActivity" >
 
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="?attr/actionBarSize"
+        android:layout_alignParentTop="true"
+        android:background="?attr/colorSurface"
+        android:elevation="4dp" >
+
+        <Spinner
+            android:id="@+id/spinner_group"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+    </com.google.android.material.appbar.MaterialToolbar>
+
     <com.github.yuukis.businessmap.widget.MapWrapperLayout
         android:id="@+id/map_relative_layout"
         android:layout_width="match_parent"
-        android:layout_height="match_parent" >
+        android:layout_height="match_parent"
+        android:layout_below="@id/toolbar" >
 
         <fragment
             android:id="@+id/contacts_map"
@@ -30,7 +45,7 @@
         android:layout_width="@dimen/slidinglayer_width"
         android:layout_height="match_parent"
         android:layout_alignParentRight="true"
-        android:layout_alignParentTop="true"
+        android:layout_below="@id/toolbar"
         slidingLayer:closeOnTapEnabled="true"
         slidingLayer:shadowDrawable="@drawable/sidebar_shadow"
         slidingLayer:shadowWidth="4dp"

--- a/app/src/main/res/layout/dialog_license.xml
+++ b/app/src/main/res/layout/dialog_license.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/dialog_license_root"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent" >
+
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar_license"
+        android:layout_width="match_parent"
+        android:layout_height="?attr/actionBarSize"
+        android:layout_alignParentTop="true"
+        android:background="?attr/colorSurface"
+        android:elevation="4dp"
+        app:title="@string/title_licenses" />
+
+    <WebView
+        android:id="@+id/webview_license"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_below="@id/toolbar_license" />
+
+</RelativeLayout>

--- a/app/src/main/res/layout/dialog_list_item.xml
+++ b/app/src/main/res/layout/dialog_list_item.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@android:id/text1"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:minHeight="?attr/listPreferredItemHeightSmall"
+    android:gravity="center_vertical"
+    android:paddingLeft="?attr/listPreferredItemPaddingLeft"
+    android:paddingRight="?attr/listPreferredItemPaddingRight"
+    android:ellipsize="marquee"
+    android:textAppearance="?attr/textAppearanceTitleMedium"
+    android:textColor="?attr/colorOnSurface" />

--- a/app/src/main/res/layout/dialog_progress.xml
+++ b/app/src/main/res/layout/dialog_progress.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:paddingStart="24dp"
+    android:paddingTop="8dp"
+    android:paddingEnd="24dp"
+    android:paddingBottom="8dp" >
+
+    <TextView
+        android:id="@+id/textview_progress_message"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="16dp" />
+
+    <com.google.android.material.progressindicator.LinearProgressIndicator
+        android:id="@+id/progress_indicator"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/fragment_about.xml
+++ b/app/src/main/res/layout/fragment_about.xml
@@ -2,7 +2,6 @@
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@android:color/background_light"
     android:padding="16dp" >
 
     <LinearLayout

--- a/app/src/main/res/layout/fragment_about.xml
+++ b/app/src/main/res/layout/fragment_about.xml
@@ -22,14 +22,14 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="20dp"
             android:text="@string/label_app_name"
-            android:textColor="#ff7f7f7f"
+            android:textColor="?attr/colorOnSurfaceVariant"
             android:textSize="14sp" />
 
         <TextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="@string/app_name"
-            android:textColor="#ff000000"
+            android:textColor="?attr/colorOnSurface"
             android:textSize="18sp" />
 
         <TextView
@@ -37,7 +37,7 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="20dp"
             android:text="@string/label_provider"
-            android:textColor="#ff7f7f7f"
+            android:textColor="?attr/colorOnSurfaceVariant"
             android:textSize="14sp" />
 
         <TextView
@@ -45,7 +45,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="@string/provider"
-            android:textColor="#ff000000"
+            android:textColor="?attr/colorOnSurface"
             android:textSize="18sp" />
 
         <TextView
@@ -53,14 +53,14 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="20dp"
             android:text="@string/label_version"
-            android:textColor="#ff7f7f7f"
+            android:textColor="?attr/colorOnSurfaceVariant"
             android:textSize="14sp" />
 
         <TextView
             android:id="@+id/textview_about_version"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:textColor="#ff000000"
+            android:textColor="?attr/colorOnSurface"
             android:textSize="20sp" />
 
         <TextView
@@ -69,7 +69,7 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="20dp"
             android:text="@string/label_licenses"
-            android:textColor="#0099cc"
+            android:textColor="?attr/colorPrimary"
             android:textSize="14sp" />
     </LinearLayout>
 

--- a/app/src/main/res/layout/gridview_contents.xml
+++ b/app/src/main/res/layout/gridview_contents.xml
@@ -18,7 +18,7 @@
         android:layout_height="wrap_content"
         android:ellipsize="end"
         android:gravity="top"
-        android:textColor="#333"
+        android:textColor="?attr/colorOnSurface"
         android:textSize="16dp" />
 
 </LinearLayout>

--- a/app/src/main/res/layout/marker_info_contents.xml
+++ b/app/src/main/res/layout/marker_info_contents.xml
@@ -58,7 +58,6 @@
 
     <Button
         android:id="@+id/other_count"
-        style="@android:style/Widget.Button"
         android:layout_width="match_parent"
         android:layout_height="24dp"
         android:layout_marginBottom="4dp"
@@ -66,7 +65,7 @@
         android:background="@drawable/infowindow_button_normal"
         android:backgroundTint="@null"
         android:padding="0dp"
-        android:textColor="#ff000000"
+        android:textColor="?attr/colorOnSecondaryContainer"
         android:textSize="14dp"
         android:textStyle="bold" />
 

--- a/app/src/main/res/layout/marker_info_contents.xml
+++ b/app/src/main/res/layout/marker_info_contents.xml
@@ -65,7 +65,7 @@
         android:background="@drawable/infowindow_button_normal"
         android:backgroundTint="@null"
         android:padding="0dp"
-        android:textColor="?attr/colorOnSecondaryContainer"
+        android:textColor="?attr/colorOnPrimary"
         android:textSize="14dp"
         android:textStyle="bold" />
 

--- a/app/src/main/res/layout/marker_info_contents.xml
+++ b/app/src/main/res/layout/marker_info_contents.xml
@@ -64,6 +64,8 @@
         android:layout_marginTop="4dp"
         android:background="@drawable/infowindow_button_normal"
         android:backgroundTint="@null"
+        android:gravity="center"
+        android:includeFontPadding="false"
         android:padding="0dp"
         android:textColor="?attr/colorOnPrimary"
         android:textSize="14dp"

--- a/app/src/main/res/layout/marker_info_contents.xml
+++ b/app/src/main/res/layout/marker_info_contents.xml
@@ -67,6 +67,11 @@
         android:gravity="center"
         android:includeFontPadding="false"
         android:padding="0dp"
+        android:paddingStart="0dp"
+        android:paddingTop="0dp"
+        android:paddingEnd="0dp"
+        android:paddingBottom="0dp"
+        android:minHeight="0dp"
         android:textColor="?attr/colorOnPrimary"
         android:textSize="14dp"
         android:textStyle="bold" />

--- a/app/src/main/res/layout/marker_info_contents.xml
+++ b/app/src/main/res/layout/marker_info_contents.xml
@@ -58,11 +58,13 @@
 
     <Button
         android:id="@+id/other_count"
+        style="@android:style/Widget.Button"
         android:layout_width="match_parent"
         android:layout_height="24dp"
         android:layout_marginBottom="4dp"
         android:layout_marginTop="4dp"
         android:background="@drawable/infowindow_button_normal"
+        android:backgroundTint="@null"
         android:padding="0dp"
         android:textColor="#ff000000"
         android:textSize="14dp"

--- a/app/src/main/res/layout/marker_info_contents.xml
+++ b/app/src/main/res/layout/marker_info_contents.xml
@@ -59,7 +59,7 @@
     <Button
         android:id="@+id/other_count"
         android:layout_width="match_parent"
-        android:layout_height="24dp"
+        android:layout_height="32dp"
         android:layout_marginBottom="4dp"
         android:layout_marginTop="4dp"
         android:background="@drawable/infowindow_button_normal"

--- a/app/src/main/res/layout/simple_spinner_dropdown_item_2line.xml
+++ b/app/src/main/res/layout/simple_spinner_dropdown_item_2line.xml
@@ -40,7 +40,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:singleLine="true"
-            android:textColor="#ff000000"
+            android:textColor="?attr/colorOnSurface"
             android:textSize="@dimen/action_bar_title_text_size" />
 
         <TextView
@@ -51,7 +51,7 @@
             android:layout_alignStart="@android:id/text1"
             android:layout_below="@android:id/text1"
             android:singleLine="true"
-            android:textColor="#ffb7b7b7"
+            android:textColor="?attr/colorOnSurfaceVariant"
             android:textSize="@dimen/action_bar_subtitle_text_size" />
     </TwoLineListItem>
 

--- a/app/src/main/res/menu/contacts_list.xml
+++ b/app/src/main/res/menu/contacts_list.xml
@@ -7,6 +7,7 @@
         android:icon="@drawable/ic_action_list"
         android:orderInCategory="200"
         android:title="@string/action_list"
+        myapp:iconTint="?attr/colorOnSurface"
         myapp:showAsAction="always">
     </item>
 

--- a/app/src/main/res/menu/main.xml
+++ b/app/src/main/res/menu/main.xml
@@ -1,10 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<menu xmlns:android="http://schemas.android.com/apk/res/android" >
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto" >
 
     <item
         android:id="@+id/action_about"
-        android:icon="@android:drawable/ic_menu_info_details"
+        android:icon="@drawable/ic_info"
         android:orderInCategory="20"
-        android:title="@string/action_about" />
+        android:title="@string/action_about"
+        app:iconTint="?attr/colorOnSurface" />
 
 </menu>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -6,6 +6,7 @@
     <string name="action_list" translatable="false">連絡先一覧</string>
     <string name="action_about" translatable="false">このアプリについて</string>
     <string name="label_licenses" translatable="false"><u>オープンソース ライセンス</u></string>
+    <string name="title_licenses" translatable="false">オープンソース ライセンス</string>
     <string name="action_contacts_detail" translatable="false">連絡先を表示</string>
     <string name="action_directions" translatable="false">経路を調べる</string>
     <string name="action_drive_navigation" translatable="false">ナビを開始</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -6,6 +6,7 @@
     <string name="action_list" translatable="false">List</string>
     <string name="action_about" translatable="false">About</string>
     <string name="label_licenses" translatable="false"><u>Open source licenses</u></string>
+    <string name="title_licenses" translatable="false">Open source licenses</string>
     <string name="action_contacts_detail" translatable="false">Show contacts</string>
     <string name="action_directions" translatable="false">Directions</string>
     <string name="action_drive_navigation" translatable="false">Drive navigation</string>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -5,7 +5,7 @@
         Base application theme, dependent on API level. This theme is replaced
         by AppBaseTheme from res/values-vXX/styles.xml on newer devices.
     -->
-    <style name="AppBaseTheme" parent="@style/Theme.AppCompat.Light">
+    <style name="AppBaseTheme" parent="@style/Theme.Material3.Light.NoActionBar">
         <!--
             Theme customizations available in newer API levels can go in
             res/values-vXX/styles.xml, while customizations related to


### PR DESCRIPTION
## Summary
- Material Components ライブラリ (`com.google.android.material:material:1.12.0`) を依存関係に追加
- テーマを `Theme.Material3.Light.NoActionBar` に変更し、ActionBar依存を廃止
- `MainActivity` のActionBarスピナーナビゲーション (`NAVIGATION_MODE_LIST`) を、レイアウト内の `MaterialToolbar` + `Spinner` に置き換え、edge-to-edge insetsロジックをToolbarの上端パディングに適用するよう見直し
- `AlertDialog.Builder` の利用箇所をすべて `MaterialAlertDialogBuilder` に置き換え (About/グループ選択/連絡先選択/アクションメニュー/エラーダイアログ)
- 非推奨の `ProgressDialog` を `MaterialAlertDialogBuilder` + `LinearProgressIndicator` のカスタムダイアログに置き換え

Closes #44

## Test plan
- [x] `./gradlew :app:assembleDebug` が成功することを確認
- [x] `./gradlew :app:lintDebug` でエラー0件を確認（既存警告のみ）
- [x] 実機/エミュレータでのMaterial3描画・edge-to-edge表示の目視確認（このセッションではエミュレータ未使用のため未実施）