### PR TITLE
Introduce Gradle Version Catalog and update dependencies

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -55,8 +55,8 @@ configurations.all {
 }
 
 dependencies {
-    implementation("androidx.appcompat:appcompat:1.7.0")
-    implementation("androidx.fragment:fragment:1.8.5")
-    implementation("com.google.android.material:material:1.12.0")
-    implementation("com.google.android.gms:play-services-maps:19.0.0")
+    implementation(libs.androidx.appcompat)
+    implementation(libs.androidx.fragment)
+    implementation(libs.material)
+    implementation(libs.play.services.maps)
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,4 @@
 plugins {
-    id("com.android.application") version "8.7.2" apply false
-    id("org.jetbrains.kotlin.android") version "2.0.21" apply false
+    alias(libs.plugins.android.application) apply false
+    alias(libs.plugins.kotlin.android) apply false
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,17 @@
+[versions]
+agp = "8.7.2"
+kotlin = "2.0.21"
+appcompat = "1.7.1"
+fragment = "1.8.9"
+material = "1.14.0"
+playServicesMaps = "20.0.0"
+
+[libraries]
+androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
+androidx-fragment = { group = "androidx.fragment", name = "fragment", version.ref = "fragment" }
+material = { group = "com.google.android.material", name = "material", version.ref = "material" }
+play-services-maps = { group = "com.google.android.gms", name = "play-services-maps", version.ref = "playServicesMaps" }
+
+[plugins]
+android-application = { id = "com.android.application", version.ref = "agp" }
+kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }


### PR DESCRIPTION
## Summary
- Add `gradle/libs.versions.toml` and migrate `build.gradle.kts` / `app/build.gradle.kts` to reference dependencies via `libs.*`
- Update appcompat (1.7.0 → 1.7.1), fragment (1.8.5 → 1.8.9), play-services-maps (19.0.0 → 20.0.0), and material (1.12.0 → 1.14.0)
- Confirmed the `kotlin-stdlib-jdk7/8` exclusion in `configurations.all` is still necessary post-update (still pulled in transitively)

AGP 9.x was left as-is since it's a separate major upgrade out of scope for this issue.

## Test plan
- [x] `./gradlew assembleDebug` succeeds
- [x] `./gradlew lintDebug` succeeds, with appcompat/fragment/material/play-services-maps no longer flagged as outdated

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)