### PR TITLE
ジオコーディング進捗ダイアログの余白・件数表示を修正

### DIFF
--- a/app/src/main/java/com/github/yuukis/businessmap/app/ProgressDialogFragment.kt
+++ b/app/src/main/java/com/github/yuukis/businessmap/app/ProgressDialogFragment.kt
@@ -33,19 +33,25 @@ class ProgressDialogFragment : DialogFragment() {
     }
 
     private var progressIndicator: LinearProgressIndicator? = null
+    private var progressCountView: TextView? = null
+    private var max = 0
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         val args = requireArguments()
         val cancelable = args.getBoolean(CANCELABLE, false)
         setCancelable(cancelable)
 
+        max = args.getInt(MAX)
         val title = args.getString(TITLE)
         val message = args.getString(MESSAGE)
         val view = layoutInflater.inflate(R.layout.dialog_progress, null)
         view.findViewById<TextView>(R.id.textview_progress_message).text = message
         progressIndicator = view.findViewById<LinearProgressIndicator>(R.id.progress_indicator).apply {
             isIndeterminate = false
-            max = args.getInt(MAX)
+            max = this@ProgressDialogFragment.max
+        }
+        progressCountView = view.findViewById<TextView>(R.id.textview_progress_count).apply {
+            text = getString(R.string.format_progress_count, 0, this@ProgressDialogFragment.max)
         }
 
         val dialog = MaterialAlertDialogBuilder(requireActivity())
@@ -58,6 +64,7 @@ class ProgressDialogFragment : DialogFragment() {
 
     fun updateProgress(value: Int) {
         progressIndicator?.setProgressCompat(value, true)
+        progressCountView?.text = getString(R.string.format_progress_count, value, max)
     }
 
     override fun onCancel(dialog: DialogInterface) {

--- a/app/src/main/res/layout/dialog_progress.xml
+++ b/app/src/main/res/layout/dialog_progress.xml
@@ -6,7 +6,7 @@
     android:paddingStart="24dp"
     android:paddingTop="8dp"
     android:paddingEnd="24dp"
-    android:paddingBottom="8dp" >
+    android:paddingBottom="16dp" >
 
     <TextView
         android:id="@+id/textview_progress_message"
@@ -17,6 +17,15 @@
     <com.google.android.material.progressindicator.LinearProgressIndicator
         android:id="@+id/progress_indicator"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content" />
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="8dp" />
+
+    <TextView
+        android:id="@+id/textview_progress_count"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="end"
+        android:textAppearance="?attr/textAppearanceBodySmall"
+        android:textColor="?attr/colorOnSurfaceVariant" />
 
 </LinearLayout>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -24,6 +24,7 @@
     <string name="message_no_data" translatable="false">(未登録)</string>
     <string name="message_no_contacts" translatable="false">このグループに連絡先はありません</string>
     <string name="message_other_items" translatable="false">他 %d 件</string>
+    <string name="format_progress_count" translatable="false">%1$d/%2$d</string>
     <string name="hint_searchview" translatable="false">連絡先を検索</string>
     <string name="group_all_contacts" translatable="false">すべての連絡先</string>
     <string name="desc_appicon" translatable="false">アイコン</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -24,6 +24,7 @@
     <string name="message_no_data" translatable="false">No data.</string>
     <string name="message_no_contacts" translatable="false">No contacts in this group.</string>
     <string name="message_other_items" translatable="false">%d other</string>
+    <string name="format_progress_count" translatable="false">%1$d/%2$d</string>
     <string name="hint_searchview" translatable="false">Find contacts</string>
     <string name="group_all_contacts" translatable="false">All contacts</string>
     <string name="desc_appicon" translatable="false">icon</string>


### PR DESCRIPTION
## Summary
#52 でMaterial Components導入に伴い `ProgressDialog` を `MaterialAlertDialogBuilder` + `LinearProgressIndicator` のカスタムダイアログに置き換えた際、実機確認が漏れていた点を修正。

- プログレスバー下の余白が狭かったため、`dialog_progress.xml` の余白を調整
- 旧 `ProgressDialog` が標準で表示していた「現在値/最大値」(例: `22/63`)のテキストが表示されなくなっていたため、`textview_progress_count` を追加して復元

## Test plan
- [x] `./gradlew :app:assembleDebug` が成功することを確認
- [x] `./gradlew :app:lintDebug` でエラー0件を確認
- [ ] 実機での住所→座標変換時のダイアログ表示確認