### PR TITLE
連絡先アクションのUI(GridView+AlertDialog)をBottomSheetDialogFragmentに置き換える

### DIFF
--- a/app/src/main/java/com/github/yuukis/businessmap/app/ContactsActionFragment.kt
+++ b/app/src/main/java/com/github/yuukis/businessmap/app/ContactsActionFragment.kt
@@ -17,7 +17,6 @@
  */
 package com.github.yuukis.businessmap.app
 
-import android.app.Dialog
 import android.content.Context
 import android.content.res.ColorStateList
 import android.os.Bundle
@@ -29,35 +28,36 @@ import android.widget.ArrayAdapter
 import android.widget.GridView
 import android.widget.ImageView
 import android.widget.TextView
-import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.FragmentActivity
 import com.github.yuukis.businessmap.R
 import com.github.yuukis.businessmap.model.ContactsItem
 import com.github.yuukis.businessmap.util.ActionUtils
 import com.google.android.material.R as MaterialR
+import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import com.google.android.material.color.MaterialColors
-import com.google.android.material.dialog.MaterialAlertDialogBuilder
 
-class ContactsActionFragment : DialogFragment(), AdapterView.OnItemClickListener {
+class ContactsActionFragment : BottomSheetDialogFragment(), AdapterView.OnItemClickListener {
 
     private var contact: ContactsItem? = null
 
-    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
         contact = requireArguments().getSerializable(KEY_CONTACTS) as? ContactsItem
 
+        val view = inflater.inflate(R.layout.fragment_contacts_action, container, false)
+
+        val titleView = view.findViewById<TextView>(R.id.title)
+        titleView.text = contact?.name
+
         val adapter = MenuAdapter(requireActivity(), R.layout.gridview_contents, ACTION_ITEMS)
-        val columns = resources.getInteger(R.integer.gridview_columns)
-        val gridView = GridView(activity)
-        gridView.numColumns = columns
+        val gridView = view.findViewById<GridView>(R.id.gridview)
         gridView.adapter = adapter
         gridView.onItemClickListener = this
-        val title = contact?.name
 
-        return MaterialAlertDialogBuilder(requireActivity())
-            .setTitle(title)
-            .setView(gridView)
-            .setNegativeButton(android.R.string.cancel, null)
-            .create()
+        return view
     }
 
     override fun onItemClick(parent: AdapterView<*>?, view: View, position: Int, id: Long) {

--- a/app/src/main/res/layout/fragment_contacts_action.xml
+++ b/app/src/main/res/layout/fragment_contacts_action.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:paddingBottom="16dp">
+
+    <TextView
+        android:id="@+id/title"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="24dp"
+        android:layout_marginTop="24dp"
+        android:layout_marginEnd="24dp"
+        android:layout_marginBottom="8dp"
+        android:textAppearance="?attr/textAppearanceHeadline6"
+        android:textColor="?attr/colorOnSurface" />
+
+    <GridView
+        android:id="@+id/gridview"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:numColumns="@integer/gridview_columns" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/fragment_contacts_action.xml
+++ b/app/src/main/res/layout/fragment_contacts_action.xml
@@ -13,7 +13,7 @@
         android:layout_marginTop="24dp"
         android:layout_marginEnd="24dp"
         android:layout_marginBottom="8dp"
-        android:textAppearance="?attr/textAppearanceHeadline6"
+        android:textAppearance="?attr/textAppearanceTitleLarge"
         android:textColor="?attr/colorOnSurface" />
 
     <GridView


### PR DESCRIPTION
## Summary
- ContactsActionFragmentをDialogFragment+MaterialAlertDialogBuilderからBottomSheetDialogFragmentに置き換え
- ボトムシート用レイアウト fragment_contacts_action.xml を新規作成(タイトル+GridView)
- 連絡先表示/ルート確認/ナビ開始の3アクションのロジックは変更なし

Closes #53

## Test plan
- [x] assembleDebug が成功すること
- [x] lintDebug が成功し、新規の警告がないこと
- [x] 実機/エミュレータで、ボトムシートとして表示され、スワイプダウンで閉じられることを確認
- [x] 3つのアクションが従来通り動作することを確認