### PR TITLE
GeocodingCacheDatabase を Room に移行

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -10,6 +10,7 @@ val localProperties = Properties().apply {
 plugins {
     id("com.android.application")
     id("org.jetbrains.kotlin.android")
+    alias(libs.plugins.ksp)
 }
 
 android {
@@ -59,4 +60,6 @@ dependencies {
     implementation(libs.androidx.fragment)
     implementation(libs.material)
     implementation(libs.play.services.maps)
+    implementation(libs.androidx.room.runtime)
+    ksp(libs.androidx.room.compiler)
 }

--- a/app/src/main/java/com/github/yuukis/businessmap/data/GeocodingCacheDatabase.kt
+++ b/app/src/main/java/com/github/yuukis/businessmap/data/GeocodingCacheDatabase.kt
@@ -17,71 +17,45 @@
  */
 package com.github.yuukis.businessmap.data
 
-import android.content.ContentValues
 import android.content.Context
-import android.database.Cursor
 import android.database.SQLException
-import android.database.sqlite.SQLiteDatabase
-import android.database.sqlite.SQLiteOpenHelper
-import android.provider.BaseColumns
-import android.util.Log
-import java.util.Locale
 
 class GeocodingCacheDatabase(context: Context) {
 
-    private var db: SQLiteDatabase? = DatabaseHelper(context).writableDatabase
-
-    interface DataColumns : BaseColumns {
-        companion object {
-            const val ID = "_id"
-            const val HASH = "hash"
-            const val LAT = "latitude"
-            const val LNG = "longitude"
-        }
-    }
+    private var database: GeocodingCacheRoomDatabase? = GeocodingCacheRoomDatabase.create(context)
 
     fun get(address: String): DoubleArray? {
-        val hash = address.hashCode()
-        val columns = arrayOf(DataColumns.LAT, DataColumns.LNG)
-        val selection = String.format(Locale.getDefault(), "%s=%d", DataColumns.HASH, hash)
-        var latlng: DoubleArray? = null
-        val cursor = query(columns, selection, null, null)
-        try {
-            if (cursor.moveToNext()) {
-                val lat: Double
-                val lng: Double
-                if (cursor.isNull(0) || cursor.isNull(1)) {
-                    lat = Double.NaN
-                    lng = Double.NaN
-                } else {
-                    lat = cursor.getDouble(0)
-                    lng = cursor.getDouble(1)
-                }
-                latlng = doubleArrayOf(lat, lng)
-            }
-        } finally {
-            cursor.close()
-        }
-        return latlng
+        val dao = database?.geocodingDao() ?: return null
+        val entity = dao.findByHash(address.hashCode()) ?: return null
+        val lat = entity.latitude ?: Double.NaN
+        val lng = entity.longitude ?: Double.NaN
+        return doubleArrayOf(lat, lng)
     }
 
     fun put(address: String, latlng: Array<Double?>?): Boolean {
         if (latlng == null || latlng.size != 2) {
             return false
         }
+        val dao = database?.geocodingDao() ?: return false
         val hash = address.hashCode()
         val lat = latlng[0] ?: Double.NaN
         val lng = latlng[1] ?: Double.NaN
+        val hasValidLatLng = !lat.isNaN() && !lng.isNaN()
 
-        val values = ContentValues()
-        values.put(DataColumns.HASH, hash)
-        if (!lat.isNaN() && !lng.isNaN()) {
-            values.put(DataColumns.LAT, lat)
-            values.put(DataColumns.LNG, lng)
-        }
         try {
-            if (!update(values, hash)) {
-                insert(values)
+            val updated = if (hasValidLatLng) {
+                dao.updateLatLngByHash(hash, lat, lng) > 0
+            } else {
+                dao.touchByHash(hash) > 0
+            }
+            if (!updated) {
+                dao.insert(
+                    GeocodingEntity(
+                        hash = hash,
+                        latitude = if (hasValidLatLng) lat else null,
+                        longitude = if (hasValidLatLng) lng else null
+                    )
+                )
             }
         } catch (e: SQLException) {
             return false
@@ -91,74 +65,10 @@ class GeocodingCacheDatabase(context: Context) {
     }
 
     fun close() {
-        val database = db
-        if (database != null && database.isOpen) {
-            // FIXME: SQLiteDatabase#closeDatabase で発生する場合がある NPE の回避
-            try {
-                database.close()
-            } catch (e: NullPointerException) {
-            }
-            db = null
+        val db = database
+        if (db != null && db.isOpen) {
+            db.close()
+            database = null
         }
-    }
-
-    private fun query(
-        columns: Array<String>,
-        selection: String,
-        selectionArgs: Array<String>?,
-        sortOrder: String?
-    ): Cursor {
-        return db!!.query(TABLE_NAME, columns, selection, selectionArgs, null, null, sortOrder)
-    }
-
-    private fun update(values: ContentValues, hash: Int): Boolean {
-        val whereClause = String.format(Locale.getDefault(), "%s=%d", DataColumns.HASH, hash)
-        val affected = db!!.update(TABLE_NAME, values, whereClause, null)
-        return affected > 0
-    }
-
-    @Throws(SQLException::class)
-    private fun insert(values: ContentValues): Long {
-        val rowId = db!!.insert(TABLE_NAME, null, values)
-
-        if (rowId > 0) {
-            return rowId
-        }
-
-        throw SQLException()
-    }
-
-    private class DatabaseHelper(context: Context) :
-        SQLiteOpenHelper(context, DATABASE_NAME, null, VERSION) {
-
-        override fun onCreate(db: SQLiteDatabase) {
-            val sb = StringBuilder()
-            sb.append("CREATE TABLE $TABLE_NAME(")
-            sb.append("${BaseColumns._ID} INTEGER PRIMARY KEY AUTOINCREMENT, ")
-            sb.append("${DataColumns.HASH} INTEGER, ")
-            sb.append("${DataColumns.LAT} REAL, ")
-            sb.append("${DataColumns.LNG} REAL ")
-            sb.append(")")
-            db.execSQL(sb.toString())
-        }
-
-        override fun onUpgrade(db: SQLiteDatabase, oldVersion: Int, newVersion: Int) {
-            Log.i(GeocodingCacheDatabase::class.java.simpleName, "Upgrade database.")
-
-            // [v1 -> v2] lat:0, lng:0 で登録されているレコードを一旦削除する
-            if (oldVersion < 2 && newVersion >= 2) {
-                val sql = "DELETE FROM %s WHERE %s = 0 AND %s = 0"
-                db.execSQL(String.format(sql, TABLE_NAME, DataColumns.LAT, DataColumns.LNG))
-            }
-        }
-
-        companion object {
-            private const val DATABASE_NAME = "business_map"
-            private const val VERSION = 2
-        }
-    }
-
-    companion object {
-        private const val TABLE_NAME = "geocoding"
     }
 }

--- a/app/src/main/java/com/github/yuukis/businessmap/data/GeocodingCacheRoomDatabase.kt
+++ b/app/src/main/java/com/github/yuukis/businessmap/data/GeocodingCacheRoomDatabase.kt
@@ -1,0 +1,53 @@
+/*
+ * GeocodingCacheRoomDatabase.kt
+ *
+ * Copyright 2026 Yuuki Shimizu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.yuukis.businessmap.data
+
+import android.content.Context
+import androidx.room.Database
+import androidx.room.Room
+import androidx.room.RoomDatabase
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
+
+@Database(entities = [GeocodingEntity::class], version = GeocodingCacheRoomDatabase.VERSION, exportSchema = false)
+abstract class GeocodingCacheRoomDatabase : RoomDatabase() {
+
+    abstract fun geocodingDao(): GeocodingDao
+
+    companion object {
+        private const val DATABASE_NAME = "business_map"
+        const val VERSION = 2
+
+        // [v1 -> v2] lat:0, lng:0 で登録されているレコードを一旦削除する
+        private val MIGRATION_1_2 = object : Migration(1, 2) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("DELETE FROM geocoding WHERE latitude = 0 AND longitude = 0")
+            }
+        }
+
+        fun create(context: Context): GeocodingCacheRoomDatabase {
+            return Room.databaseBuilder(
+                context.applicationContext,
+                GeocodingCacheRoomDatabase::class.java,
+                DATABASE_NAME
+            )
+                .addMigrations(MIGRATION_1_2)
+                .build()
+        }
+    }
+}

--- a/app/src/main/java/com/github/yuukis/businessmap/data/GeocodingCacheRoomDatabase.kt
+++ b/app/src/main/java/com/github/yuukis/businessmap/data/GeocodingCacheRoomDatabase.kt
@@ -36,7 +36,6 @@ abstract class GeocodingCacheRoomDatabase : RoomDatabase() {
                 GeocodingCacheRoomDatabase::class.java,
                 DATABASE_NAME
             )
-                // 旧 SQLiteOpenHelper 版のキャッシュ(住所→緯度経度)は破棄して作り直す
                 .fallbackToDestructiveMigration()
                 .build()
         }

--- a/app/src/main/java/com/github/yuukis/businessmap/data/GeocodingCacheRoomDatabase.kt
+++ b/app/src/main/java/com/github/yuukis/businessmap/data/GeocodingCacheRoomDatabase.kt
@@ -21,24 +21,14 @@ import android.content.Context
 import androidx.room.Database
 import androidx.room.Room
 import androidx.room.RoomDatabase
-import androidx.room.migration.Migration
-import androidx.sqlite.db.SupportSQLiteDatabase
 
-@Database(entities = [GeocodingEntity::class], version = GeocodingCacheRoomDatabase.VERSION, exportSchema = false)
+@Database(entities = [GeocodingEntity::class], version = 1, exportSchema = false)
 abstract class GeocodingCacheRoomDatabase : RoomDatabase() {
 
     abstract fun geocodingDao(): GeocodingDao
 
     companion object {
         private const val DATABASE_NAME = "business_map"
-        const val VERSION = 2
-
-        // [v1 -> v2] lat:0, lng:0 で登録されているレコードを一旦削除する
-        private val MIGRATION_1_2 = object : Migration(1, 2) {
-            override fun migrate(db: SupportSQLiteDatabase) {
-                db.execSQL("DELETE FROM geocoding WHERE latitude = 0 AND longitude = 0")
-            }
-        }
 
         fun create(context: Context): GeocodingCacheRoomDatabase {
             return Room.databaseBuilder(
@@ -46,7 +36,8 @@ abstract class GeocodingCacheRoomDatabase : RoomDatabase() {
                 GeocodingCacheRoomDatabase::class.java,
                 DATABASE_NAME
             )
-                .addMigrations(MIGRATION_1_2)
+                // 旧 SQLiteOpenHelper 版のキャッシュ(住所→緯度経度)は破棄して作り直す
+                .fallbackToDestructiveMigration()
                 .build()
         }
     }

--- a/app/src/main/java/com/github/yuukis/businessmap/data/GeocodingDao.kt
+++ b/app/src/main/java/com/github/yuukis/businessmap/data/GeocodingDao.kt
@@ -1,0 +1,38 @@
+/*
+ * GeocodingDao.kt
+ *
+ * Copyright 2026 Yuuki Shimizu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.yuukis.businessmap.data
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.Query
+
+@Dao
+interface GeocodingDao {
+
+    @Query("SELECT * FROM geocoding WHERE hash = :hash LIMIT 1")
+    fun findByHash(hash: Int): GeocodingEntity?
+
+    @Insert
+    fun insert(entity: GeocodingEntity): Long
+
+    @Query("UPDATE geocoding SET hash = hash WHERE hash = :hash")
+    fun touchByHash(hash: Int): Int
+
+    @Query("UPDATE geocoding SET latitude = :latitude, longitude = :longitude WHERE hash = :hash")
+    fun updateLatLngByHash(hash: Int, latitude: Double, longitude: Double): Int
+}

--- a/app/src/main/java/com/github/yuukis/businessmap/data/GeocodingEntity.kt
+++ b/app/src/main/java/com/github/yuukis/businessmap/data/GeocodingEntity.kt
@@ -27,7 +27,7 @@ data class GeocodingEntity(
     @ColumnInfo(name = "_id")
     val id: Long = 0,
     @ColumnInfo(name = "hash")
-    val hash: Int?,
+    val hash: Int,
     @ColumnInfo(name = "latitude")
     val latitude: Double?,
     @ColumnInfo(name = "longitude")

--- a/app/src/main/java/com/github/yuukis/businessmap/data/GeocodingEntity.kt
+++ b/app/src/main/java/com/github/yuukis/businessmap/data/GeocodingEntity.kt
@@ -1,0 +1,35 @@
+/*
+ * GeocodingEntity.kt
+ *
+ * Copyright 2026 Yuuki Shimizu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.yuukis.businessmap.data
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "geocoding")
+data class GeocodingEntity(
+    @PrimaryKey(autoGenerate = true)
+    @ColumnInfo(name = "_id")
+    val id: Long = 0,
+    @ColumnInfo(name = "hash")
+    val hash: Int?,
+    @ColumnInfo(name = "latitude")
+    val latitude: Double?,
+    @ColumnInfo(name = "longitude")
+    val longitude: Double?
+)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,5 @@
 plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.kotlin.android) apply false
+    alias(libs.plugins.ksp) apply false
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,17 +1,22 @@
 [versions]
 agp = "8.7.2"
 kotlin = "2.0.21"
+ksp = "2.0.21-1.0.28"
 appcompat = "1.7.1"
 fragment = "1.8.9"
 material = "1.14.0"
 playServicesMaps = "20.0.0"
+room = "2.6.1"
 
 [libraries]
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
 androidx-fragment = { group = "androidx.fragment", name = "fragment", version.ref = "fragment" }
 material = { group = "com.google.android.material", name = "material", version.ref = "material" }
 play-services-maps = { group = "com.google.android.gms", name = "play-services-maps", version.ref = "playServicesMaps" }
+androidx-room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "room" }
+androidx-room-compiler = { group = "androidx.room", name = "room-compiler", version.ref = "room" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
+ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }


### PR DESCRIPTION
## Summary
- `GeocodingCacheDatabase`(geocoding キャッシュ用テーブル)の実装を生 `SQLiteOpenHelper` から Room に移行
- 既存ユーザーのキャッシュデータ(住所→緯度経度)は破棄して問題ないため、旧DBからの非破壊移行は行わず `fallbackToDestructiveMigration()` でシンプルに対応
- `GeocodingCacheDatabase` の公開API(`get` / `put` / `close`)は変更せず維持したため、呼び出し元の `ContactsTaskFragment` は無変更

Closes #47

## Test plan
- [x] `:app:assembleDebug` が成功することを確認
- [x] `:app:lintDebug` を実行し、新規の致命的な問題が無いことを確認
- [ ] 実機/エミュレータでの動作確認(キャッシュの新規登録・読み込み・更新)は未実施

🤖 Generated with [Claude Code](https://claude.com/claude-code)