### PR TITLE
テスト基盤の追加（ユニットテスト・最低限のUIテスト）

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -26,6 +26,8 @@ android {
 
         manifestPlaceholders["mapsApiKey"] =
             localProperties.getProperty("MAPS_API_KEY", "")
+
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 
     buildTypes {
@@ -67,4 +69,10 @@ dependencies {
     implementation(libs.androidx.lifecycle.viewmodel.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.kotlinx.coroutines.android)
+
+    testImplementation(libs.junit)
+
+    androidTestImplementation(libs.junit)
+    androidTestImplementation(libs.androidx.test.ext.junit)
+    androidTestImplementation(libs.androidx.test.runner)
 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -75,4 +75,5 @@ dependencies {
     androidTestImplementation(libs.junit)
     androidTestImplementation(libs.androidx.test.ext.junit)
     androidTestImplementation(libs.androidx.test.runner)
+    androidTestImplementation(libs.androidx.test.core)
 }

--- a/app/src/androidTest/java/com/github/yuukis/businessmap/app/MainActivityPermissionTest.kt
+++ b/app/src/androidTest/java/com/github/yuukis/businessmap/app/MainActivityPermissionTest.kt
@@ -1,0 +1,23 @@
+package com.github.yuukis.businessmap.app
+
+import androidx.lifecycle.Lifecycle
+import androidx.test.core.app.ActivityScenario
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Verifies MainActivity launches without crashing when the contacts and
+ * location permissions have not been granted yet.
+ */
+@RunWith(AndroidJUnit4::class)
+class MainActivityPermissionTest {
+
+    @Test
+    fun launchesWithoutCrashingWhenPermissionsAreMissing() {
+        ActivityScenario.launch(MainActivity::class.java).use { scenario ->
+            assertEquals(Lifecycle.State.RESUMED, scenario.state)
+        }
+    }
+}

--- a/app/src/androidTest/java/com/github/yuukis/businessmap/app/MainActivityPermissionTest.kt
+++ b/app/src/androidTest/java/com/github/yuukis/businessmap/app/MainActivityPermissionTest.kt
@@ -1,9 +1,12 @@
 package com.github.yuukis.businessmap.app
 
+import android.Manifest
 import androidx.lifecycle.Lifecycle
 import androidx.test.core.app.ActivityScenario
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
 import org.junit.Assert.assertTrue
+import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 
@@ -15,6 +18,19 @@ import org.junit.runner.RunWith
  */
 @RunWith(AndroidJUnit4::class)
 class MainActivityPermissionTest {
+
+    @Before
+    fun revokeRuntimePermissions() {
+        val packageName = InstrumentationRegistry.getInstrumentation().targetContext.packageName
+        val automation = InstrumentationRegistry.getInstrumentation().uiAutomation
+        for (permission in listOf(
+            Manifest.permission.READ_CONTACTS,
+            Manifest.permission.ACCESS_FINE_LOCATION,
+            Manifest.permission.ACCESS_COARSE_LOCATION
+        )) {
+            automation.executeShellCommand("pm revoke $packageName $permission").close()
+        }
+    }
 
     @Test
     fun launchesWithoutCrashingWhenPermissionsAreMissing() {

--- a/app/src/androidTest/java/com/github/yuukis/businessmap/app/MainActivityPermissionTest.kt
+++ b/app/src/androidTest/java/com/github/yuukis/businessmap/app/MainActivityPermissionTest.kt
@@ -3,13 +3,15 @@ package com.github.yuukis.businessmap.app
 import androidx.lifecycle.Lifecycle
 import androidx.test.core.app.ActivityScenario
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 
 /**
  * Verifies MainActivity launches without crashing when the contacts and
- * location permissions have not been granted yet.
+ * location permissions have not been granted yet. The runtime permission
+ * dialog this triggers takes the foreground, so the activity itself only
+ * reaches STARTED rather than RESUMED.
  */
 @RunWith(AndroidJUnit4::class)
 class MainActivityPermissionTest {
@@ -17,7 +19,7 @@ class MainActivityPermissionTest {
     @Test
     fun launchesWithoutCrashingWhenPermissionsAreMissing() {
         ActivityScenario.launch(MainActivity::class.java).use { scenario ->
-            assertEquals(Lifecycle.State.RESUMED, scenario.state)
+            assertTrue(scenario.state.isAtLeast(Lifecycle.State.STARTED))
         }
     }
 }

--- a/app/src/androidTest/java/com/github/yuukis/businessmap/app/MainActivityPermissionTest.kt
+++ b/app/src/androidTest/java/com/github/yuukis/businessmap/app/MainActivityPermissionTest.kt
@@ -10,12 +10,6 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 
-/**
- * Verifies MainActivity launches without crashing when the contacts and
- * location permissions have not been granted yet. The runtime permission
- * dialog this triggers takes the foreground, so the activity itself only
- * reaches STARTED rather than RESUMED.
- */
 @RunWith(AndroidJUnit4::class)
 class MainActivityPermissionTest {
 

--- a/app/src/main/java/com/github/yuukis/businessmap/util/StringJUtils.kt
+++ b/app/src/main/java/com/github/yuukis/businessmap/util/StringJUtils.kt
@@ -42,7 +42,7 @@ object StringJUtils {
     @JvmStatic
     fun mergeChar(c1: Char, c2: Char): Char {
         if (c2 == 'ﾞ') {
-            if ("ｶｷｸｹｺｻｼｽｾｿﾀﾁﾂﾃﾄﾊﾋﾌﾍﾎ".indexOf(c1) > 0) {
+            if ("ｶｷｸｹｺｻｼｽｾｿﾀﾁﾂﾃﾄﾊﾋﾌﾍﾎ".indexOf(c1) >= 0) {
                 return when (c1) {
                     'ｶ' -> 'ガ'
                     'ｷ' -> 'ギ'
@@ -68,7 +68,7 @@ object StringJUtils {
                 }
             }
         } else if (c2 == 'ﾟ') {
-            if ("ﾊﾋﾌﾍﾎ".indexOf(c1) > 0) {
+            if ("ﾊﾋﾌﾍﾎ".indexOf(c1) >= 0) {
                 return when (c1) {
                     'ﾊ' -> 'パ'
                     'ﾋ' -> 'ピ'

--- a/app/src/test/java/com/github/yuukis/businessmap/model/ContactsItemTest.kt
+++ b/app/src/test/java/com/github/yuukis/businessmap/model/ContactsItemTest.kt
@@ -1,0 +1,66 @@
+package com.github.yuukis.businessmap.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Test
+
+class ContactsItemTest {
+
+    private fun newItem(groupId: Long = 1L) = ContactsItem(
+        cid = 100L,
+        name = "山田太郎",
+        phonetic = "ヤマダタロウ",
+        groupId = groupId,
+        address = "東京都",
+        note = "note",
+        companyName = "会社"
+    ).apply {
+        setLat(35.0)
+        setLng(139.0)
+    }
+
+    @Test
+    fun `equals ignores groupId`() {
+        val a = newItem(groupId = 1L)
+        val b = newItem(groupId = 2L)
+
+        assertEquals(a, b)
+    }
+
+    @Test
+    fun `hashCode ignores groupId`() {
+        val a = newItem(groupId = 1L)
+        val b = newItem(groupId = 2L)
+
+        assertEquals(a.hashCode(), b.hashCode())
+    }
+
+    @Test
+    fun `equals detects differing cid`() {
+        val a = newItem()
+        val b = ContactsItem(
+            cid = 999L,
+            name = a.name,
+            phonetic = a.phonetic,
+            groupId = a.groupId,
+            address = a.address,
+            note = a.note,
+            companyName = a.companyName
+        ).apply {
+            setLat(35.0)
+            setLng(139.0)
+        }
+
+        assertNotEquals(a, b)
+    }
+
+    @Test
+    fun `setLat and setLng treat NaN as null`() {
+        val item = newItem()
+        item.setLat(Double.NaN)
+        item.setLng(Double.NaN)
+
+        assertEquals(null, item.lat)
+        assertEquals(null, item.lng)
+    }
+}

--- a/app/src/test/java/com/github/yuukis/businessmap/util/ContactsItemComparatorTest.kt
+++ b/app/src/test/java/com/github/yuukis/businessmap/util/ContactsItemComparatorTest.kt
@@ -14,8 +14,6 @@ class ContactsItemComparatorTest {
 
     @Before
     fun setLocale() {
-        // Collator depends on the default locale, so pin it to keep
-        // the kana ordering assertions deterministic across environments.
         originalLocale = Locale.getDefault()
         Locale.setDefault(Locale.JAPAN)
     }

--- a/app/src/test/java/com/github/yuukis/businessmap/util/ContactsItemComparatorTest.kt
+++ b/app/src/test/java/com/github/yuukis/businessmap/util/ContactsItemComparatorTest.kt
@@ -1,0 +1,85 @@
+package com.github.yuukis.businessmap.util
+
+import com.github.yuukis.businessmap.model.ContactsItem
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import java.util.Locale
+
+class ContactsItemComparatorTest {
+
+    private lateinit var originalLocale: Locale
+
+    @Before
+    fun setLocale() {
+        // Collator depends on the default locale, so pin it to keep
+        // the kana ordering assertions deterministic across environments.
+        originalLocale = Locale.getDefault()
+        Locale.setDefault(Locale.JAPAN)
+    }
+
+    @After
+    fun restoreLocale() {
+        Locale.setDefault(originalLocale)
+    }
+
+    private fun item(cid: Long, name: String?, phonetic: String?) = ContactsItem(
+        cid = cid,
+        name = name,
+        phonetic = phonetic,
+        groupId = 0L,
+        address = null,
+        note = null,
+        companyName = null
+    )
+
+    @Test
+    fun `sorts by phonetic when present`() {
+        val a = item(1L, "鈴木一郎", "スズキイチロウ")
+        val b = item(2L, "山田太郎", "ヤマダタロウ")
+
+        val result = listOf(b, a).sortedWith(ContactsItemComparator())
+
+        assertEquals(listOf(a, b), result)
+    }
+
+    @Test
+    fun `falls back to name when phonetic is missing`() {
+        val a = item(1L, "あ", null)
+        val b = item(2L, "ん", "")
+
+        val result = listOf(b, a).sortedWith(ContactsItemComparator())
+
+        assertEquals(listOf(a, b), result)
+    }
+
+    @Test
+    fun `items without sort key sort after items with one`() {
+        val withName = item(1L, "あ", null)
+        val withoutName = item(2L, null, null)
+
+        val result = listOf(withoutName, withName).sortedWith(ContactsItemComparator())
+
+        assertEquals(listOf(withName, withoutName), result)
+    }
+
+    @Test
+    fun `breaks ties on equal sort key by cid`() {
+        val first = item(1L, "同じ名前", "オナジナマエ")
+        val second = item(2L, "同じ名前", "オナジナマエ")
+
+        val result = listOf(second, first).sortedWith(ContactsItemComparator())
+
+        assertEquals(listOf(first, second), result)
+    }
+
+    @Test
+    fun `items with no sort key at all fall back to cid order`() {
+        val a = item(1L, null, null)
+        val b = item(2L, null, null)
+
+        assertTrue(ContactsItemComparator().compare(a, b) < 0)
+    }
+}

--- a/app/src/test/java/com/github/yuukis/businessmap/util/StringJUtilsTest.kt
+++ b/app/src/test/java/com/github/yuukis/businessmap/util/StringJUtilsTest.kt
@@ -1,0 +1,52 @@
+package com.github.yuukis.businessmap.util
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class StringJUtilsTest {
+
+    @Test
+    fun `hankakuKatakanaToZenkakuKatakana converts a single character`() {
+        assertEquals('ア', StringJUtils.hankakuKatakanaToZenkakuKatakana('ｱ'))
+    }
+
+    @Test
+    fun `hankakuKatakanaToZenkakuKatakana leaves non-katakana characters untouched`() {
+        assertEquals('A', StringJUtils.hankakuKatakanaToZenkakuKatakana('A'))
+    }
+
+    @Test
+    fun `hankakuKatakanaToZenkakuKatakana converts a plain string`() {
+        assertEquals("アイウエオ", StringJUtils.hankakuKatakanaToZenkakuKatakana("ｱｲｳｴｵ"))
+    }
+
+    @Test
+    fun `hankakuKatakanaToZenkakuKatakana merges voiced sound marks`() {
+        assertEquals("ガギグゲゴ", StringJUtils.hankakuKatakanaToZenkakuKatakana("ｶﾞｷﾞｸﾞｹﾞｺﾞ"))
+    }
+
+    @Test
+    fun `hankakuKatakanaToZenkakuKatakana merges semi-voiced sound marks`() {
+        assertEquals("パピプペポ", StringJUtils.hankakuKatakanaToZenkakuKatakana("ﾊﾟﾋﾟﾌﾟﾍﾟﾎﾟ"))
+    }
+
+    @Test
+    fun `hankakuKatakanaToZenkakuKatakana handles a single trailing character after merging`() {
+        assertEquals("ガア", StringJUtils.hankakuKatakanaToZenkakuKatakana("ｶﾞｱ"))
+    }
+
+    @Test
+    fun `zenkakuHiraganaToZenkakuKatakana converts hiragana only`() {
+        assertEquals("ヤマダタロウABC123", StringJUtils.zenkakuHiraganaToZenkakuKatakana("やまだたろうABC123"))
+    }
+
+    @Test
+    fun `convertToKatakana converts hiragana to katakana`() {
+        assertEquals("ヤマダタロウ", StringJUtils.convertToKatakana("やまだたろう"))
+    }
+
+    @Test
+    fun `convertToKatakana handles mixed hankaku katakana and hiragana input`() {
+        assertEquals("ガギグゲゴア", StringJUtils.convertToKatakana("ｶﾞｷﾞｸﾞｹﾞｺﾞあ"))
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,8 +10,14 @@ playServicesMaps = "20.0.0"
 room = "2.6.1"
 lifecycle = "2.8.7"
 coroutines = "1.9.0"
+junit = "4.13.2"
+androidxTestExtJunit = "1.2.1"
+androidxTestRunner = "1.6.2"
 
 [libraries]
+junit = { group = "junit", name = "junit", version.ref = "junit" }
+androidx-test-ext-junit = { group = "androidx.test.ext", name = "junit", version.ref = "androidxTestExtJunit" }
+androidx-test-runner = { group = "androidx.test", name = "runner", version.ref = "androidxTestRunner" }
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
 androidx-activity-ktx = { group = "androidx.activity", name = "activity-ktx", version.ref = "activity" }
 androidx-fragment = { group = "androidx.fragment", name = "fragment", version.ref = "fragment" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.7.2"
+agp = "8.13.0"
 kotlin = "2.0.21"
 ksp = "2.0.21-1.0.28"
 appcompat = "1.7.1"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,11 +13,13 @@ coroutines = "1.9.0"
 junit = "4.13.2"
 androidxTestExtJunit = "1.2.1"
 androidxTestRunner = "1.6.2"
+androidxTestCore = "1.6.1"
 
 [libraries]
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-test-ext-junit = { group = "androidx.test.ext", name = "junit", version.ref = "androidxTestExtJunit" }
 androidx-test-runner = { group = "androidx.test", name = "runner", version.ref = "androidxTestRunner" }
+androidx-test-core = { group = "androidx.test", name = "core", version.ref = "androidxTestCore" }
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
 androidx-activity-ktx = { group = "androidx.activity", name = "activity-ktx", version.ref = "activity" }
 androidx-fragment = { group = "androidx.fragment", name = "fragment", version.ref = "fragment" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Summary
- junit / AndroidX Test を依存に追加し、`testInstrumentationRunner` を設定
- `ContactsItemTest` / `ContactsItemComparatorTest` / `StringJUtilsTest` を追加（優先度順）
- `StringJUtils.mergeChar()` の濁音・半濁音結合が各仮名行の先頭文字（ｶ・ﾊなど）で抜け落ちるオフバイワン不具合をテスト作成時に発見し修正
- 権限未許可状態で `MainActivity` がクラッシュせず起動できることを確認するインストルメンテーションテストを追加
- AGP 8.7.2 → 8.13.0、Gradle 8.9 → 8.13 にアップデート。AGP 8.7.2のUTP(Unified Test Platform)ランチャーがGoogle自身のバンドルクラス内で`kotlin.enums.EnumEntriesKt`をロードできず`connectedAndroidTest`が0件実行のまま失敗する既知の不具合があったため（同一8.x系列のマイナーアップグレードで回避）

## Test plan
- [x] `./gradlew :app:testDebugUnitTest` — 18件全て成功
- [x] `./gradlew :app:assembleDebugAndroidTest` — ビルド成功
- [x] `./gradlew :app:assembleRelease`（R8/minify含む） — ビルド成功
- [ ] 実機/エミュレータで `./gradlew connectedAndroidTest` の実行確認をお願いします（このサンドボックスには端末がなく未実施）

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)