### PR TITLE
[段階3] ContactsGroupDialogFragmentをJetpack Composeに移行

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -88,6 +88,7 @@ dependencies {
     androidTestImplementation(libs.androidx.test.ext.junit)
     androidTestImplementation(libs.androidx.test.runner)
     androidTestImplementation(libs.androidx.test.core)
+    androidTestImplementation(libs.androidx.test.espresso.core)
     androidTestImplementation(libs.androidx.compose.ui.test.junit4)
     debugImplementation(libs.androidx.compose.ui.test.manifest)
 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -29,6 +29,11 @@ android {
             localProperties.getProperty("MAPS_API_KEY", "")
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunnerArguments["clearPackageData"] = "true"
+    }
+
+    testOptions {
+        execution = "ANDROIDX_TEST_ORCHESTRATOR"
     }
 
     buildTypes {
@@ -91,4 +96,5 @@ dependencies {
     androidTestImplementation(libs.androidx.test.espresso.core)
     androidTestImplementation(libs.androidx.compose.ui.test.junit4)
     debugImplementation(libs.androidx.compose.ui.test.manifest)
+    androidTestUtil(libs.androidx.test.orchestrator)
 }

--- a/app/src/androidTest/java/com/github/yuukis/businessmap/app/AboutDialogFragmentTest.kt
+++ b/app/src/androidTest/java/com/github/yuukis/businessmap/app/AboutDialogFragmentTest.kt
@@ -5,6 +5,9 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.test.core.app.ActivityScenario
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.github.yuukis.businessmap.R
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -15,6 +18,13 @@ class AboutDialogFragmentTest {
     @get:Rule
     val composeTestRule = createEmptyComposeRule()
 
+    private val targetContext get() = InstrumentationRegistry.getInstrumentation().targetContext
+
+    @Before
+    fun grantRuntimePermissions() {
+        TestPermissions.grantContactsAndLocation()
+    }
+
     @Test
     fun showsAppNameAndProvider() {
         ActivityScenario.launch(MainActivity::class.java).use { scenario ->
@@ -24,9 +34,9 @@ class AboutDialogFragmentTest {
             }
             composeTestRule.waitForIdle()
 
-            composeTestRule.onNodeWithText("Business Map").assertExists()
-            composeTestRule.onNodeWithText("Yuuki Shimizu").assertExists()
-            composeTestRule.onNodeWithText("Open source licenses").assertExists()
+            composeTestRule.onNodeWithText(targetContext.getString(R.string.app_name)).assertExists()
+            composeTestRule.onNodeWithText(targetContext.getString(R.string.provider)).assertExists()
+            composeTestRule.onNodeWithText(targetContext.getString(R.string.label_licenses)).assertExists()
         }
     }
 
@@ -39,10 +49,10 @@ class AboutDialogFragmentTest {
             }
             composeTestRule.waitForIdle()
 
-            composeTestRule.onNodeWithText("Open source licenses").performClick()
+            composeTestRule.onNodeWithText(targetContext.getString(R.string.label_licenses)).performClick()
             composeTestRule.waitForIdle()
 
-            composeTestRule.onNodeWithText("Business Map").assertDoesNotExist()
+            composeTestRule.onNodeWithText(targetContext.getString(R.string.app_name)).assertDoesNotExist()
         }
     }
 }

--- a/app/src/androidTest/java/com/github/yuukis/businessmap/app/AboutDialogFragmentTest.kt
+++ b/app/src/androidTest/java/com/github/yuukis/businessmap/app/AboutDialogFragmentTest.kt
@@ -20,6 +20,7 @@ class AboutDialogFragmentTest {
         ActivityScenario.launch(MainActivity::class.java).use { scenario ->
             scenario.onActivity { activity ->
                 AboutDialogFragment.showDialog(activity)
+                activity.supportFragmentManager.executePendingTransactions()
             }
             composeTestRule.waitForIdle()
 
@@ -34,6 +35,7 @@ class AboutDialogFragmentTest {
         ActivityScenario.launch(MainActivity::class.java).use { scenario ->
             scenario.onActivity { activity ->
                 AboutDialogFragment.showDialog(activity)
+                activity.supportFragmentManager.executePendingTransactions()
             }
             composeTestRule.waitForIdle()
 

--- a/app/src/androidTest/java/com/github/yuukis/businessmap/app/AboutDialogFragmentTest.kt
+++ b/app/src/androidTest/java/com/github/yuukis/businessmap/app/AboutDialogFragmentTest.kt
@@ -11,7 +11,6 @@ import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.github.yuukis.businessmap.R
-import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -28,11 +27,6 @@ class AboutDialogFragmentTest {
     @Before
     fun grantRuntimePermissions() {
         TestPermissions.grantContactsAndLocation()
-    }
-
-    @After
-    fun revokeRuntimePermissions() {
-        TestPermissions.revokeContactsAndLocation()
     }
 
     @Test

--- a/app/src/androidTest/java/com/github/yuukis/businessmap/app/AboutDialogFragmentTest.kt
+++ b/app/src/androidTest/java/com/github/yuukis/businessmap/app/AboutDialogFragmentTest.kt
@@ -11,6 +11,7 @@ import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.github.yuukis.businessmap.R
+import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -27,6 +28,11 @@ class AboutDialogFragmentTest {
     @Before
     fun grantRuntimePermissions() {
         TestPermissions.grantContactsAndLocation()
+    }
+
+    @After
+    fun revokeRuntimePermissions() {
+        TestPermissions.revokeContactsAndLocation()
     }
 
     @Test

--- a/app/src/androidTest/java/com/github/yuukis/businessmap/app/AboutDialogFragmentTest.kt
+++ b/app/src/androidTest/java/com/github/yuukis/businessmap/app/AboutDialogFragmentTest.kt
@@ -4,6 +4,10 @@ import androidx.compose.ui.test.junit4.createEmptyComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.test.core.app.ActivityScenario
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.github.yuukis.businessmap.R
@@ -50,9 +54,14 @@ class AboutDialogFragmentTest {
             composeTestRule.waitForIdle()
 
             composeTestRule.onNodeWithText(targetContext.getString(R.string.label_licenses)).performClick()
+            scenario.onActivity { activity ->
+                activity.supportFragmentManager.executePendingTransactions()
+            }
             composeTestRule.waitForIdle()
 
-            composeTestRule.onNodeWithText(targetContext.getString(R.string.app_name)).assertDoesNotExist()
+            // LicenseDialogFragment is a separate native (non-Compose) dialog stacked on
+            // top of AboutDialogFragment; AboutDialogFragment is not dismissed underneath it.
+            onView(withText(R.string.title_licenses)).check(matches(isDisplayed()))
         }
     }
 }

--- a/app/src/androidTest/java/com/github/yuukis/businessmap/app/ContactsActionFragmentTest.kt
+++ b/app/src/androidTest/java/com/github/yuukis/businessmap/app/ContactsActionFragmentTest.kt
@@ -8,7 +8,6 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.github.yuukis.businessmap.R
 import com.github.yuukis.businessmap.model.ContactsItem
-import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -25,11 +24,6 @@ class ContactsActionFragmentTest {
     @Before
     fun grantRuntimePermissions() {
         TestPermissions.grantContactsAndLocation()
-    }
-
-    @After
-    fun revokeRuntimePermissions() {
-        TestPermissions.revokeContactsAndLocation()
     }
 
     private fun newContact() = ContactsItem(

--- a/app/src/androidTest/java/com/github/yuukis/businessmap/app/ContactsActionFragmentTest.kt
+++ b/app/src/androidTest/java/com/github/yuukis/businessmap/app/ContactsActionFragmentTest.kt
@@ -8,6 +8,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.github.yuukis.businessmap.R
 import com.github.yuukis.businessmap.model.ContactsItem
+import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -24,6 +25,11 @@ class ContactsActionFragmentTest {
     @Before
     fun grantRuntimePermissions() {
         TestPermissions.grantContactsAndLocation()
+    }
+
+    @After
+    fun revokeRuntimePermissions() {
+        TestPermissions.revokeContactsAndLocation()
     }
 
     private fun newContact() = ContactsItem(

--- a/app/src/androidTest/java/com/github/yuukis/businessmap/app/ContactsActionFragmentTest.kt
+++ b/app/src/androidTest/java/com/github/yuukis/businessmap/app/ContactsActionFragmentTest.kt
@@ -31,6 +31,7 @@ class ContactsActionFragmentTest {
         ActivityScenario.launch(MainActivity::class.java).use { scenario ->
             scenario.onActivity { activity ->
                 ContactsActionFragment.showDialog(activity, newContact())
+                activity.supportFragmentManager.executePendingTransactions()
             }
             composeTestRule.waitForIdle()
 
@@ -46,6 +47,7 @@ class ContactsActionFragmentTest {
         ActivityScenario.launch(MainActivity::class.java).use { scenario ->
             scenario.onActivity { activity ->
                 ContactsActionFragment.showDialog(activity, newContact())
+                activity.supportFragmentManager.executePendingTransactions()
             }
             composeTestRule.waitForIdle()
 

--- a/app/src/androidTest/java/com/github/yuukis/businessmap/app/ContactsActionFragmentTest.kt
+++ b/app/src/androidTest/java/com/github/yuukis/businessmap/app/ContactsActionFragmentTest.kt
@@ -5,7 +5,10 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.test.core.app.ActivityScenario
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.github.yuukis.businessmap.R
 import com.github.yuukis.businessmap.model.ContactsItem
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -15,6 +18,13 @@ class ContactsActionFragmentTest {
 
     @get:Rule
     val composeTestRule = createEmptyComposeRule()
+
+    private val targetContext get() = InstrumentationRegistry.getInstrumentation().targetContext
+
+    @Before
+    fun grantRuntimePermissions() {
+        TestPermissions.grantContactsAndLocation()
+    }
 
     private fun newContact() = ContactsItem(
         cid = 1L,
@@ -36,9 +46,9 @@ class ContactsActionFragmentTest {
             composeTestRule.waitForIdle()
 
             composeTestRule.onNodeWithText("Taro Yamada").assertExists()
-            composeTestRule.onNodeWithText("Show contacts").assertExists()
-            composeTestRule.onNodeWithText("Directions").assertExists()
-            composeTestRule.onNodeWithText("Drive navigation").assertExists()
+            composeTestRule.onNodeWithText(targetContext.getString(R.string.action_contacts_detail)).assertExists()
+            composeTestRule.onNodeWithText(targetContext.getString(R.string.action_directions)).assertExists()
+            composeTestRule.onNodeWithText(targetContext.getString(R.string.action_drive_navigation)).assertExists()
         }
     }
 
@@ -51,10 +61,11 @@ class ContactsActionFragmentTest {
             }
             composeTestRule.waitForIdle()
 
-            composeTestRule.onNodeWithText("Show contacts").performClick()
+            val showContactsLabel = targetContext.getString(R.string.action_contacts_detail)
+            composeTestRule.onNodeWithText(showContactsLabel).performClick()
             composeTestRule.waitForIdle()
 
-            composeTestRule.onNodeWithText("Show contacts").assertDoesNotExist()
+            composeTestRule.onNodeWithText(showContactsLabel).assertDoesNotExist()
         }
     }
 }

--- a/app/src/androidTest/java/com/github/yuukis/businessmap/app/ContactsGroupDialogFragmentTest.kt
+++ b/app/src/androidTest/java/com/github/yuukis/businessmap/app/ContactsGroupDialogFragmentTest.kt
@@ -1,0 +1,32 @@
+package com.github.yuukis.businessmap.app
+
+import androidx.compose.ui.test.junit4.createEmptyComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.lifecycle.Lifecycle
+import androidx.test.core.app.ActivityScenario
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class ContactsGroupDialogFragmentTest {
+
+    @get:Rule
+    val composeTestRule = createEmptyComposeRule()
+
+    @Test
+    fun showsAllContactsGroupAndSelectingItFinishesTheActivity() {
+        ActivityScenario.launch(IncomingShortcutActivity::class.java).use { scenario ->
+            composeTestRule.waitForIdle()
+
+            composeTestRule.onNodeWithText("All contacts").assertExists()
+            composeTestRule.onNodeWithText("All contacts").performClick()
+            composeTestRule.waitForIdle()
+
+            assertEquals(Lifecycle.State.DESTROYED, scenario.state)
+        }
+    }
+}

--- a/app/src/androidTest/java/com/github/yuukis/businessmap/app/ContactsGroupDialogFragmentTest.kt
+++ b/app/src/androidTest/java/com/github/yuukis/businessmap/app/ContactsGroupDialogFragmentTest.kt
@@ -38,8 +38,12 @@ class ContactsGroupDialogFragmentTest {
             val allContactsLabel = targetContext.getString(R.string.group_all_contacts)
             composeTestRule.onNodeWithText(allContactsLabel).assertExists()
             composeTestRule.onNodeWithText(allContactsLabel).performClick()
-            composeTestRule.waitForIdle()
 
+            // finish() drives the activity to DESTROYED asynchronously via the system process;
+            // waitForIdle() only settles Compose, so poll instead of asserting immediately.
+            composeTestRule.waitUntil(timeoutMillis = 5_000) {
+                scenario.state == Lifecycle.State.DESTROYED
+            }
             assertEquals(Lifecycle.State.DESTROYED, scenario.state)
         }
     }

--- a/app/src/androidTest/java/com/github/yuukis/businessmap/app/ContactsGroupDialogFragmentTest.kt
+++ b/app/src/androidTest/java/com/github/yuukis/businessmap/app/ContactsGroupDialogFragmentTest.kt
@@ -8,6 +8,7 @@ import androidx.test.core.app.ActivityScenario
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.github.yuukis.businessmap.R
+import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Rule
@@ -25,6 +26,11 @@ class ContactsGroupDialogFragmentTest {
     @Before
     fun grantRuntimePermissions() {
         TestPermissions.grantContactsAndLocation()
+    }
+
+    @After
+    fun revokeRuntimePermissions() {
+        TestPermissions.revokeContactsAndLocation()
     }
 
     @Test

--- a/app/src/androidTest/java/com/github/yuukis/businessmap/app/ContactsGroupDialogFragmentTest.kt
+++ b/app/src/androidTest/java/com/github/yuukis/businessmap/app/ContactsGroupDialogFragmentTest.kt
@@ -1,6 +1,5 @@
 package com.github.yuukis.businessmap.app
 
-import android.Manifest
 import androidx.compose.ui.test.junit4.createEmptyComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
@@ -8,6 +7,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.test.core.app.ActivityScenario
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
+import com.github.yuukis.businessmap.R
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Rule
@@ -20,12 +20,11 @@ class ContactsGroupDialogFragmentTest {
     @get:Rule
     val composeTestRule = createEmptyComposeRule()
 
+    private val targetContext get() = InstrumentationRegistry.getInstrumentation().targetContext
+
     @Before
-    fun grantContactsPermission() {
-        val packageName = InstrumentationRegistry.getInstrumentation().targetContext.packageName
-        InstrumentationRegistry.getInstrumentation().uiAutomation
-            .executeShellCommand("pm grant $packageName ${Manifest.permission.READ_CONTACTS}")
-            .close()
+    fun grantRuntimePermissions() {
+        TestPermissions.grantContactsAndLocation()
     }
 
     @Test
@@ -33,8 +32,9 @@ class ContactsGroupDialogFragmentTest {
         ActivityScenario.launch(IncomingShortcutActivity::class.java).use { scenario ->
             composeTestRule.waitForIdle()
 
-            composeTestRule.onNodeWithText("All contacts").assertExists()
-            composeTestRule.onNodeWithText("All contacts").performClick()
+            val allContactsLabel = targetContext.getString(R.string.group_all_contacts)
+            composeTestRule.onNodeWithText(allContactsLabel).assertExists()
+            composeTestRule.onNodeWithText(allContactsLabel).performClick()
             composeTestRule.waitForIdle()
 
             assertEquals(Lifecycle.State.DESTROYED, scenario.state)

--- a/app/src/androidTest/java/com/github/yuukis/businessmap/app/ContactsGroupDialogFragmentTest.kt
+++ b/app/src/androidTest/java/com/github/yuukis/businessmap/app/ContactsGroupDialogFragmentTest.kt
@@ -30,6 +30,9 @@ class ContactsGroupDialogFragmentTest {
     @Test
     fun showsAllContactsGroupAndSelectingItFinishesTheActivity() {
         ActivityScenario.launch(IncomingShortcutActivity::class.java).use { scenario ->
+            scenario.onActivity { activity ->
+                activity.supportFragmentManager.executePendingTransactions()
+            }
             composeTestRule.waitForIdle()
 
             val allContactsLabel = targetContext.getString(R.string.group_all_contacts)

--- a/app/src/androidTest/java/com/github/yuukis/businessmap/app/ContactsGroupDialogFragmentTest.kt
+++ b/app/src/androidTest/java/com/github/yuukis/businessmap/app/ContactsGroupDialogFragmentTest.kt
@@ -1,12 +1,15 @@
 package com.github.yuukis.businessmap.app
 
+import android.Manifest
 import androidx.compose.ui.test.junit4.createEmptyComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.lifecycle.Lifecycle
 import androidx.test.core.app.ActivityScenario
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
 import org.junit.Assert.assertEquals
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -16,6 +19,14 @@ class ContactsGroupDialogFragmentTest {
 
     @get:Rule
     val composeTestRule = createEmptyComposeRule()
+
+    @Before
+    fun grantContactsPermission() {
+        val packageName = InstrumentationRegistry.getInstrumentation().targetContext.packageName
+        InstrumentationRegistry.getInstrumentation().uiAutomation
+            .executeShellCommand("pm grant $packageName ${Manifest.permission.READ_CONTACTS}")
+            .close()
+    }
 
     @Test
     fun showsAllContactsGroupAndSelectingItFinishesTheActivity() {

--- a/app/src/androidTest/java/com/github/yuukis/businessmap/app/ContactsGroupDialogFragmentTest.kt
+++ b/app/src/androidTest/java/com/github/yuukis/businessmap/app/ContactsGroupDialogFragmentTest.kt
@@ -8,7 +8,6 @@ import androidx.test.core.app.ActivityScenario
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.github.yuukis.businessmap.R
-import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Rule
@@ -26,11 +25,6 @@ class ContactsGroupDialogFragmentTest {
     @Before
     fun grantRuntimePermissions() {
         TestPermissions.grantContactsAndLocation()
-    }
-
-    @After
-    fun revokeRuntimePermissions() {
-        TestPermissions.revokeContactsAndLocation()
     }
 
     @Test

--- a/app/src/androidTest/java/com/github/yuukis/businessmap/app/MainActivityPermissionTest.kt
+++ b/app/src/androidTest/java/com/github/yuukis/businessmap/app/MainActivityPermissionTest.kt
@@ -1,10 +1,8 @@
 package com.github.yuukis.businessmap.app
 
-import android.Manifest
 import androidx.lifecycle.Lifecycle
 import androidx.test.core.app.ActivityScenario
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import androidx.test.platform.app.InstrumentationRegistry
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -15,15 +13,7 @@ class MainActivityPermissionTest {
 
     @Before
     fun revokeRuntimePermissions() {
-        val packageName = InstrumentationRegistry.getInstrumentation().targetContext.packageName
-        val automation = InstrumentationRegistry.getInstrumentation().uiAutomation
-        for (permission in listOf(
-            Manifest.permission.READ_CONTACTS,
-            Manifest.permission.ACCESS_FINE_LOCATION,
-            Manifest.permission.ACCESS_COARSE_LOCATION
-        )) {
-            automation.executeShellCommand("pm revoke $packageName $permission").close()
-        }
+        TestPermissions.revokeContactsAndLocation()
     }
 
     @Test

--- a/app/src/androidTest/java/com/github/yuukis/businessmap/app/TestPermissions.kt
+++ b/app/src/androidTest/java/com/github/yuukis/businessmap/app/TestPermissions.kt
@@ -13,14 +13,39 @@ internal object TestPermissions {
      * focused.
      */
     fun grantContactsAndLocation() {
-        val packageName = InstrumentationRegistry.getInstrumentation().targetContext.packageName
-        val automation = InstrumentationRegistry.getInstrumentation().uiAutomation
+        forEachPermission { permission ->
+            uiAutomation().executeShellCommand("pm grant ${packageName()} $permission").close()
+        }
+    }
+
+    /**
+     * Revoking a dangerous permission from a process that is still holding
+     * resources backed by it (an open ContentProvider connection, a location
+     * callback, etc.) can make the platform kill that process to enforce the
+     * revoke. Since androidTest classes share one app process for the whole
+     * instrumentation run, leaving these granted after a test that actually
+     * exercised them (e.g. ContactsGroupDialogFragmentTest querying
+     * contacts) can crash a later, unrelated test (e.g.
+     * MainActivityPermissionTest) when IT revokes the same permissions.
+     * Call this from @After so each test leaves the process in a clean
+     * state for whichever test runs next.
+     */
+    fun revokeContactsAndLocation() {
+        forEachPermission { permission ->
+            uiAutomation().executeShellCommand("pm revoke ${packageName()} $permission").close()
+        }
+    }
+
+    private fun forEachPermission(action: (String) -> Unit) {
         for (permission in listOf(
             Manifest.permission.READ_CONTACTS,
             Manifest.permission.ACCESS_FINE_LOCATION,
             Manifest.permission.ACCESS_COARSE_LOCATION
         )) {
-            automation.executeShellCommand("pm grant $packageName $permission").close()
+            action(permission)
         }
     }
+
+    private fun packageName() = InstrumentationRegistry.getInstrumentation().targetContext.packageName
+    private fun uiAutomation() = InstrumentationRegistry.getInstrumentation().uiAutomation
 }

--- a/app/src/androidTest/java/com/github/yuukis/businessmap/app/TestPermissions.kt
+++ b/app/src/androidTest/java/com/github/yuukis/businessmap/app/TestPermissions.kt
@@ -1,0 +1,26 @@
+package com.github.yuukis.businessmap.app
+
+import android.Manifest
+import androidx.test.platform.app.InstrumentationRegistry
+
+internal object TestPermissions {
+
+    /**
+     * MainActivity.requestMissingPermissions() pops a system permission
+     * dialog for any of these that are missing, which steals window focus
+     * and makes any ComposeView shown on top of it undiscoverable by
+     * Compose Test. Granting them up front keeps MainActivity resumed and
+     * focused.
+     */
+    fun grantContactsAndLocation() {
+        val packageName = InstrumentationRegistry.getInstrumentation().targetContext.packageName
+        val automation = InstrumentationRegistry.getInstrumentation().uiAutomation
+        for (permission in listOf(
+            Manifest.permission.READ_CONTACTS,
+            Manifest.permission.ACCESS_FINE_LOCATION,
+            Manifest.permission.ACCESS_COARSE_LOCATION
+        )) {
+            automation.executeShellCommand("pm grant $packageName $permission").close()
+        }
+    }
+}

--- a/app/src/androidTest/java/com/github/yuukis/businessmap/app/TestPermissions.kt
+++ b/app/src/androidTest/java/com/github/yuukis/businessmap/app/TestPermissions.kt
@@ -11,28 +11,26 @@ internal object TestPermissions {
      * and makes any ComposeView shown on top of it undiscoverable by
      * Compose Test. Granting them up front keeps MainActivity resumed and
      * focused.
+     *
+     * Uses UiAutomation.grantRuntimePermission()/revokeRuntimePermission()
+     * rather than shelling out to `pm grant`/`pm revoke`: those shell
+     * commands operate on the live, currently-instrumented app process from
+     * the outside and can crash it (the platform itself warns "is more
+     * robust and should be used instead of 'pm revoke'" when you do this).
      */
     fun grantContactsAndLocation() {
         forEachPermission { permission ->
-            uiAutomation().executeShellCommand("pm grant ${packageName()} $permission").close()
+            uiAutomation().grantRuntimePermission(packageName(), permission)
         }
     }
 
     /**
-     * Revoking a dangerous permission from a process that is still holding
-     * resources backed by it (an open ContentProvider connection, a location
-     * callback, etc.) can make the platform kill that process to enforce the
-     * revoke. Since androidTest classes share one app process for the whole
-     * instrumentation run, leaving these granted after a test that actually
-     * exercised them (e.g. ContactsGroupDialogFragmentTest querying
-     * contacts) can crash a later, unrelated test (e.g.
-     * MainActivityPermissionTest) when IT revokes the same permissions.
-     * Call this from @After so each test leaves the process in a clean
-     * state for whichever test runs next.
+     * See grantContactsAndLocation(). Call this from @After so each test
+     * leaves the process in a clean state for whichever test runs next.
      */
     fun revokeContactsAndLocation() {
         forEachPermission { permission ->
-            uiAutomation().executeShellCommand("pm revoke ${packageName()} $permission").close()
+            uiAutomation().revokeRuntimePermission(packageName(), permission)
         }
     }
 

--- a/app/src/main/java/com/github/yuukis/businessmap/app/ContactsGroupDialogFragment.kt
+++ b/app/src/main/java/com/github/yuukis/businessmap/app/ContactsGroupDialogFragment.kt
@@ -19,9 +19,23 @@ package com.github.yuukis.businessmap.app
 
 import android.app.Dialog
 import android.content.Context
-import android.content.DialogInterface
 import android.os.Bundle
-import android.widget.ArrayAdapter
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.unit.dp
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.FragmentActivity
 import com.github.yuukis.businessmap.R
@@ -29,7 +43,7 @@ import com.github.yuukis.businessmap.model.ContactsGroup
 import com.github.yuukis.businessmap.util.ContactUtils
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 
-class ContactsGroupDialogFragment : DialogFragment(), DialogInterface.OnClickListener {
+class ContactsGroupDialogFragment : DialogFragment() {
 
     interface OnSelectListener {
         fun onContactsGroupSelected(group: ContactsGroup?)
@@ -47,23 +61,32 @@ class ContactsGroupDialogFragment : DialogFragment(), DialogInterface.OnClickLis
     }
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
-        val items = getContactsGroupTitleArray()
-        val adapter = ArrayAdapter(requireActivity(), R.layout.dialog_list_item, android.R.id.text1, items)
-        return MaterialAlertDialogBuilder(requireActivity())
+        val activity = requireActivity()
+        val groups = groupList
+
+        val view = ComposeView(activity).apply {
+            setContent {
+                MaterialTheme {
+                    Surface(color = Color.Transparent) {
+                        ContactsGroupList(
+                            groups = groups,
+                            onItemClick = { group ->
+                                listener?.onContactsGroupSelected(group)
+                                dismiss()
+                            }
+                        )
+                    }
+                }
+            }
+        }
+
+        return MaterialAlertDialogBuilder(activity)
             .setTitle(R.string.action_select_group)
-            .setAdapter(adapter, this)
-            .setNegativeButton(android.R.string.cancel, this)
+            .setView(view)
+            .setNegativeButton(android.R.string.cancel) { _, _ ->
+                listener?.onContactsGroupSelected(null)
+            }
             .create()
-    }
-
-    override fun onClick(dialog: DialogInterface, which: Int) {
-        val currentListener = listener ?: return
-        val group = if (which != DialogInterface.BUTTON_NEGATIVE) groupList[which] else null
-        currentListener.onContactsGroupSelected(group)
-    }
-
-    private fun getContactsGroupTitleArray(): Array<CharSequence?> {
-        return Array(groupList.size) { i -> groupList[i].title }
     }
 
     companion object {
@@ -78,6 +101,31 @@ class ContactsGroupDialogFragment : DialogFragment(), DialogInterface.OnClickLis
         fun showDialog(activity: FragmentActivity) {
             val manager = activity.supportFragmentManager
             newInstance().show(manager, TAG)
+        }
+    }
+}
+
+@Composable
+private fun ContactsGroupList(
+    groups: List<ContactsGroup>,
+    onItemClick: (ContactsGroup) -> Unit
+) {
+    LazyColumn {
+        items(groups) { group ->
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable { onItemClick(group) }
+                    .heightIn(min = 48.dp)
+                    .padding(horizontal = 24.dp),
+                contentAlignment = Alignment.CenterStart
+            ) {
+                Text(
+                    text = group.title.orEmpty(),
+                    style = MaterialTheme.typography.titleMedium,
+                    color = MaterialTheme.colorScheme.onSurface
+                )
+            }
         }
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,12 +15,14 @@ junit = "4.13.2"
 androidxTestExtJunit = "1.2.1"
 androidxTestRunner = "1.6.2"
 androidxTestCore = "1.6.1"
+espresso = "3.7.0"
 
 [libraries]
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-test-ext-junit = { group = "androidx.test.ext", name = "junit", version.ref = "androidxTestExtJunit" }
 androidx-test-runner = { group = "androidx.test", name = "runner", version.ref = "androidxTestRunner" }
 androidx-test-core = { group = "androidx.test", name = "core", version.ref = "androidxTestCore" }
+androidx-test-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espresso" }
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
 androidx-activity-ktx = { group = "androidx.activity", name = "activity-ktx", version.ref = "activity" }
 androidx-fragment = { group = "androidx.fragment", name = "fragment", version.ref = "fragment" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,6 +16,7 @@ androidxTestExtJunit = "1.2.1"
 androidxTestRunner = "1.6.2"
 androidxTestCore = "1.6.1"
 espresso = "3.7.0"
+androidxTestOrchestrator = "1.6.1"
 
 [libraries]
 junit = { group = "junit", name = "junit", version.ref = "junit" }
@@ -23,6 +24,7 @@ androidx-test-ext-junit = { group = "androidx.test.ext", name = "junit", version
 androidx-test-runner = { group = "androidx.test", name = "runner", version.ref = "androidxTestRunner" }
 androidx-test-core = { group = "androidx.test", name = "core", version.ref = "androidxTestCore" }
 androidx-test-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espresso" }
+androidx-test-orchestrator = { group = "androidx.test", name = "orchestrator", version.ref = "androidxTestOrchestrator" }
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
 androidx-activity-ktx = { group = "androidx.activity", name = "activity-ktx", version.ref = "activity" }
 androidx-fragment = { group = "androidx.fragment", name = "fragment", version.ref = "fragment" }


### PR DESCRIPTION
## Summary
- Issue #51 (Jetpack Composeへの段階的移行) の3例目として `ContactsGroupDialogFragment` をComposeView化
- `ArrayAdapter` + `MaterialAlertDialogBuilder.setAdapter()` によるグループ選択リストを `ComposeView` 上の `LazyColumn` に置き換え
- キャンセル時の挙動(`onContactsGroupSelected(null)`)はネイティブの `setNegativeButton` のまま維持。項目選択時はリスナー呼び出し後に `dismiss()` する
- `OnSelectListener` インターフェースと `showDialog()` の呼び出し契約は変更なし(利用元は `IncomingShortcutActivity` のみ)
- 表示項目とタップ時の挙動を検証するCompose UIテスト (`ContactsGroupDialogFragmentTest`) を追加

#65, #66と同じ方針で、ComposeViewを既存のDialog/Fragment APIに埋め込む形の段階的移行を継続しています。なお `ContactsItemsDialogFragment` も同じ `dialog_list_item.xml` を使う類似のリストダイアログのため、未移行のまま残し、レイアウトファイルは削除していません。

## Test plan
- [x] `./gradlew :app:assembleDebug` が成功すること
- [x] `./gradlew :app:assembleDebugAndroidTest` が成功すること
- [x] `./gradlew :app:testDebugUnitTest` が成功すること
- [ ] 実機/エミュレータで `ContactsGroupDialogFragmentTest` を実行し、表示・タップ動作を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)