### PR TITLE
MainActivityのバックキー処理をBackHandlerに置き換え

### DIFF
--- a/app/src/main/java/com/github/yuukis/businessmap/app/MainActivity.kt
+++ b/app/src/main/java/com/github/yuukis/businessmap/app/MainActivity.kt
@@ -20,10 +20,10 @@ package com.github.yuukis.businessmap.app
 import android.Manifest
 import android.content.pm.PackageManager
 import android.os.Bundle
-import android.view.KeyEvent
 import android.view.View
 import android.view.ViewGroup
 import android.view.WindowManager
+import androidx.activity.compose.BackHandler
 import androidx.activity.compose.setContent
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
@@ -171,20 +171,6 @@ class MainActivity : AppCompatActivity(),
         viewModel.cancelContactsTask()
     }
 
-    override fun dispatchKeyEvent(event: KeyEvent): Boolean {
-        if (event.action == KeyEvent.ACTION_DOWN) {
-            when (event.keyCode) {
-                KeyEvent.KEYCODE_BACK -> {
-                    if (viewModel.isContactsListVisible.value) {
-                        viewModel.setContactsListVisible(false)
-                        return true
-                    }
-                }
-            }
-        }
-        return super.dispatchKeyEvent(event)
-    }
-
     private fun mapFragment(): ContactsMapFragment? =
         supportFragmentManager.findFragmentById(R.id.contacts_map) as? ContactsMapFragment
 
@@ -277,6 +263,15 @@ private fun MainScreen(
     val selectedGroupIndex by viewModel.selectedGroupIndex.collectAsState()
     val isRunning by viewModel.isRunning.collectAsState()
     val isListVisible by viewModel.isContactsListVisible.collectAsState()
+
+    // Handles the hardware back button, the 3-button nav back action, and
+    // the back gesture (including predictive back) uniformly - unlike
+    // overriding Activity.dispatchKeyEvent(KEYCODE_BACK), which only ever
+    // sees a real KeyEvent and would silently stop working if this app
+    // later opts into predictive back (android:enableOnBackInvokedCallback).
+    BackHandler(enabled = isListVisible) {
+        viewModel.setContactsListVisible(false)
+    }
 
     Scaffold(
         topBar = {

--- a/app/src/main/java/com/github/yuukis/businessmap/app/MainActivity.kt
+++ b/app/src/main/java/com/github/yuukis/businessmap/app/MainActivity.kt
@@ -264,11 +264,6 @@ private fun MainScreen(
     val isRunning by viewModel.isRunning.collectAsState()
     val isListVisible by viewModel.isContactsListVisible.collectAsState()
 
-    // Handles the hardware back button, the 3-button nav back action, and
-    // the back gesture (including predictive back) uniformly - unlike
-    // overriding Activity.dispatchKeyEvent(KEYCODE_BACK), which only ever
-    // sees a real KeyEvent and would silently stop working if this app
-    // later opts into predictive back (android:enableOnBackInvokedCallback).
     BackHandler(enabled = isListVisible) {
         viewModel.setContactsListVisible(false)
     }


### PR DESCRIPTION
## Summary
- `MainActivity#dispatchKeyEvent`によるバックキー処理(`KEYCODE_BACK`)を、Composeの`BackHandler`に置き換えた
- `BackHandler(enabled = isContactsListVisible)`として、連絡先一覧パネルが表示中のときだけ有効化し、閉じる処理を行う
- `dispatchKeyEvent`は実際のKeyEventの配送に依存しており、将来このアプリがpredictive back(`android:enableOnBackInvokedCallback`)へopt-inした場合、あるいはAndroid側でデフォルトが切り替わった場合に機能しなくなる可能性があった。`BackHandler`はハードウェアバック・3ボタンナビ・ジェスチャーバック(predictive back含む)のいずれでも確実に動作する

## Test plan
- [x] `./gradlew assembleDebug` が成功すること
- [x] `./gradlew assembleDebugAndroidTest` が成功すること
- [x] `./gradlew testDebugUnitTest` が成功すること
- [ ] 実機/エミュレータで連絡先一覧パネル表示中にバックキー/バックジェスチャーで閉じることを確認（本サンドボックスにはエミュレータがないため未実施）

Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)