### PR TITLE
ライト/ダークモード対応(端末設定に追従)

### DIFF
--- a/app/src/main/java/com/github/yuukis/businessmap/app/AboutDialogFragment.kt
+++ b/app/src/main/java/com/github/yuukis/businessmap/app/AboutDialogFragment.kt
@@ -56,7 +56,7 @@ class AboutDialogFragment : DialogFragment() {
 
         val view = ComposeView(activity).apply {
             setContent {
-                MaterialTheme {
+                AppTheme {
                     Surface(color = Color.Transparent) {
                         AboutContent(
                             version = version,

--- a/app/src/main/java/com/github/yuukis/businessmap/app/AppTheme.kt
+++ b/app/src/main/java/com/github/yuukis/businessmap/app/AppTheme.kt
@@ -1,0 +1,17 @@
+package com.github.yuukis.businessmap.app
+
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.lightColorScheme
+import androidx.compose.runtime.Composable
+
+/**
+ * Shared Compose theme used by [MainActivity] and the dialog fragments,
+ * switching between light/dark color schemes based on the device setting.
+ */
+@Composable
+fun AppTheme(content: @Composable () -> Unit) {
+    val colorScheme = if (isSystemInDarkTheme()) darkColorScheme() else lightColorScheme()
+    MaterialTheme(colorScheme = colorScheme, content = content)
+}

--- a/app/src/main/java/com/github/yuukis/businessmap/app/ContactsActionFragment.kt
+++ b/app/src/main/java/com/github/yuukis/businessmap/app/ContactsActionFragment.kt
@@ -70,7 +70,7 @@ class ContactsActionFragment : BottomSheetDialogFragment() {
 
         return ComposeView(requireContext()).apply {
             setContent {
-                MaterialTheme {
+                AppTheme {
                     Surface {
                         ContactsActionContent(
                             contactName = contact?.name.orEmpty(),

--- a/app/src/main/java/com/github/yuukis/businessmap/app/ContactsGroupDialogFragment.kt
+++ b/app/src/main/java/com/github/yuukis/businessmap/app/ContactsGroupDialogFragment.kt
@@ -66,7 +66,7 @@ class ContactsGroupDialogFragment : DialogFragment() {
 
         val view = ComposeView(activity).apply {
             setContent {
-                MaterialTheme {
+                AppTheme {
                     Surface(color = Color.Transparent) {
                         ContactsGroupList(
                             groups = groups,

--- a/app/src/main/java/com/github/yuukis/businessmap/app/ContactsItemsDialogFragment.kt
+++ b/app/src/main/java/com/github/yuukis/businessmap/app/ContactsItemsDialogFragment.kt
@@ -70,7 +70,7 @@ class ContactsItemsDialogFragment : DialogFragment() {
 
         val view = ComposeView(activity).apply {
             setContent {
-                MaterialTheme {
+                AppTheme {
                     Surface(color = Color.Transparent) {
                         ContactsItemsList(
                             items = items,

--- a/app/src/main/java/com/github/yuukis/businessmap/app/MainActivity.kt
+++ b/app/src/main/java/com/github/yuukis/businessmap/app/MainActivity.kt
@@ -116,7 +116,7 @@ class MainActivity : AppCompatActivity(),
         super.onCreate(savedInstanceState)
         window.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_HIDDEN)
         setContent {
-            MaterialTheme {
+            AppTheme {
                 MainScreen(
                     viewModel = viewModel,
                     fragmentManager = supportFragmentManager,
@@ -514,7 +514,7 @@ private fun BoxScope.ContactsListPanel(
             ) {
                 Text(
                     text = stringResource(R.string.message_no_contacts),
-                    color = Color(0xFF999999),
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
             }
         } else {

--- a/app/src/main/java/com/github/yuukis/businessmap/app/ProgressDialogFragment.kt
+++ b/app/src/main/java/com/github/yuukis/businessmap/app/ProgressDialogFragment.kt
@@ -59,7 +59,7 @@ class ProgressDialogFragment : DialogFragment() {
 
         val view = ComposeView(requireContext()).apply {
             setContent {
-                MaterialTheme {
+                AppTheme {
                     Surface(color = Color.Transparent) {
                         ProgressContent(
                             message = message,

--- a/app/src/main/res/values-night/styles.xml
+++ b/app/src/main/res/values-night/styles.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <style name="AppBaseTheme" parent="@style/Theme.Material3.DayNight.NoActionBar">
+        <item name="android:windowLightStatusBar">false</item>
+    </style>
+
+</resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -5,7 +5,7 @@
         Base application theme, dependent on API level. This theme is replaced
         by AppBaseTheme from res/values-vXX/styles.xml on newer devices.
     -->
-    <style name="AppBaseTheme" parent="@style/Theme.Material3.Light.NoActionBar">
+    <style name="AppBaseTheme" parent="@style/Theme.Material3.DayNight.NoActionBar">
         <!--
             Theme customizations available in newer API levels can go in
             res/values-vXX/styles.xml, while customizations related to

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -11,6 +11,7 @@
             res/values-vXX/styles.xml, while customizations related to
             backward-compatibility can go here.
         -->
+        <item name="android:windowLightStatusBar">true</item>
     </style>
 
     <!-- Application theme. -->


### PR DESCRIPTION
## Summary
- ベーステーマを `Theme.Material3.Light.NoActionBar` から `Theme.Material3.DayNight.NoActionBar` に変更し、端末のダークモード設定に追従させる
- Compose側に共通の `AppTheme` を新設し、`isSystemInDarkTheme()` でlight/darkの`colorScheme`を切り替え、各DialogFragment/MainActivityの`MaterialTheme {}`呼び出しを置き換え
- `MainActivity`内でハードコードされていたグレー文字色(`Color(0xFF999999)`)を`colorScheme.onSurfaceVariant`に統一

地図のInfoWindow(`marker_info_contents.xml`)は独立したカードデザインのため本対応の対象外としています。

Closes #81

## Test plan
- [x] `./gradlew :app:compileDebugKotlin`
- [x] `./gradlew :app:testDebugUnitTest`
- [x] 実機/エミュレータで端末のダーク/ライト切替時の表示確認