### PR TITLE
アバウト画面にプライバシーポリシーへのリンクを追加

### DIFF
--- a/app/src/main/java/com/github/yuukis/businessmap/app/AboutDialogFragment.kt
+++ b/app/src/main/java/com/github/yuukis/businessmap/app/AboutDialogFragment.kt
@@ -18,8 +18,10 @@
 package com.github.yuukis.businessmap.app
 
 import android.app.Dialog
+import android.content.Intent
 import android.content.pm.PackageManager
 import android.content.pm.PackageManager.NameNotFoundException
+import android.net.Uri
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.foundation.Image
@@ -45,6 +47,7 @@ import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.fragment.app.DialogFragment
+import androidx.fragment.app.FragmentActivity
 import com.github.yuukis.businessmap.R
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 
@@ -60,7 +63,8 @@ class AboutDialogFragment : DialogFragment() {
                     Surface(color = Color.Transparent) {
                         AboutContent(
                             version = version,
-                            onLicensesClick = { LicenseDialogFragment.showDialog(activity) }
+                            onLicensesClick = { LicenseDialogFragment.showDialog(activity) },
+                            onPrivacyPolicyClick = { openPrivacyPolicy(activity) }
                         )
                     }
                 }
@@ -72,6 +76,11 @@ class AboutDialogFragment : DialogFragment() {
             .setView(view)
             .setPositiveButton(android.R.string.ok, null)
             .create()
+    }
+
+    private fun openPrivacyPolicy(activity: FragmentActivity) {
+        val url = activity.getString(R.string.url_privacy_policy)
+        activity.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(url)))
     }
 
     private fun getVersion(): String {
@@ -105,7 +114,8 @@ class AboutDialogFragment : DialogFragment() {
 @Composable
 private fun AboutContent(
     version: String,
-    onLicensesClick: () -> Unit
+    onLicensesClick: () -> Unit,
+    onPrivacyPolicyClick: () -> Unit
 ) {
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
@@ -131,6 +141,16 @@ private fun AboutContent(
             modifier = Modifier
                 .padding(top = 20.dp)
                 .clickable(onClick = onLicensesClick)
+        )
+        Text(
+            text = stringResource(R.string.label_privacy_policy),
+            color = MaterialTheme.colorScheme.primary,
+            textDecoration = TextDecoration.Underline,
+            fontSize = 14.sp,
+            textAlign = TextAlign.Center,
+            modifier = Modifier
+                .padding(top = 12.dp)
+                .clickable(onClick = onPrivacyPolicyClick)
         )
     }
 }

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -32,5 +32,6 @@
     <string name="action_clear_search" translatable="false">検索文字をクリア</string>
     <string name="group_all_contacts" translatable="false">すべての連絡先</string>
     <string name="desc_appicon" translatable="false">アイコン</string>
+    <string name="label_privacy_policy" translatable="false"><u>プライバシーポリシー</u></string>
 
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -5,7 +5,7 @@
     <string name="provider" translatable="false">しみず ゆうき</string>
     <string name="action_list" translatable="false">連絡先一覧</string>
     <string name="action_about" translatable="false">このアプリについて</string>
-    <string name="label_licenses" translatable="false"><u>オープンソース ライセンス</u></string>
+    <string name="label_licenses" translatable="false">オープンソース ライセンス</string>
     <string name="title_licenses" translatable="false">オープンソース ライセンス</string>
     <string name="action_contacts_detail" translatable="false">連絡先を表示</string>
     <string name="action_directions" translatable="false">経路を調べる</string>
@@ -32,6 +32,6 @@
     <string name="action_clear_search" translatable="false">検索文字をクリア</string>
     <string name="group_all_contacts" translatable="false">すべての連絡先</string>
     <string name="desc_appicon" translatable="false">アイコン</string>
-    <string name="label_privacy_policy" translatable="false"><u>プライバシーポリシー</u></string>
+    <string name="label_privacy_policy" translatable="false">プライバシーポリシー</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -5,7 +5,7 @@
     <string name="provider" translatable="false">Yuuki Shimizu</string>
     <string name="action_list" translatable="false">List</string>
     <string name="action_about" translatable="false">About</string>
-    <string name="label_licenses" translatable="false"><u>Open source licenses</u></string>
+    <string name="label_licenses" translatable="false">Open source licenses</string>
     <string name="title_licenses" translatable="false">Open source licenses</string>
     <string name="action_contacts_detail" translatable="false">Show contacts</string>
     <string name="action_directions" translatable="false">Directions</string>
@@ -36,7 +36,7 @@
     <string name="desc_back" translatable="false">Back</string>
     <string name="action_view_license_text" translatable="false">View full license text</string>
     <string name="message_no_licenses" translatable="false">No third-party licenses.</string>
-    <string name="label_privacy_policy" translatable="false"><u>Privacy Policy</u></string>
+    <string name="label_privacy_policy" translatable="false">Privacy Policy</string>
     <string name="url_privacy_policy" translatable="false">https://yuukis.github.io/businessmap/privacy-policy.html</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -36,5 +36,7 @@
     <string name="desc_back" translatable="false">Back</string>
     <string name="action_view_license_text" translatable="false">View full license text</string>
     <string name="message_no_licenses" translatable="false">No third-party licenses.</string>
+    <string name="label_privacy_policy" translatable="false"><u>Privacy Policy</u></string>
+    <string name="url_privacy_policy" translatable="false">https://yuukis.github.io/businessmap/privacy-policy.html</string>
 
 </resources>


### PR DESCRIPTION
## Summary
- ストア公開対応として、連絡先・位置情報を扱う本アプリのプライバシーポリシーページ(https://yuukis.github.io/businessmap/privacy-policy.html, gh-pagesに公開済み)へのリンクをアバウト画面に追加
- `strings.xml` / `values-ja/strings.xml` に文言を追加

## Test plan
- [x] `./gradlew :app:compileDebugKotlin` が成功すること
- [x] アバウト画面で「Privacy Policy」リンクをタップし、ブラウザでポリシーページが開くことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)