### PR TITLE
非推奨APIの解消とminSdkを26に引き上げ

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -21,7 +21,7 @@ android {
 
     defaultConfig {
         applicationId = "com.github.yuukis.businessmap"
-        minSdk = 24
+        minSdk = 26
         targetSdk = 35
         versionCode = 224
         versionName = "1.4.0224"

--- a/app/src/main/java/com/github/yuukis/businessmap/app/ContactsActionFragment.kt
+++ b/app/src/main/java/com/github/yuukis/businessmap/app/ContactsActionFragment.kt
@@ -48,6 +48,7 @@ import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.res.integerResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import androidx.core.os.BundleCompat
 import androidx.fragment.app.FragmentActivity
 import com.github.yuukis.businessmap.R
 import com.github.yuukis.businessmap.model.ContactsItem
@@ -72,7 +73,7 @@ class ContactsActionFragment : BottomSheetDialogFragment() {
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        contact = requireArguments().getSerializable(KEY_CONTACTS) as? ContactsItem
+        contact = BundleCompat.getSerializable(requireArguments(), KEY_CONTACTS, ContactsItem::class.java)
 
         return ComposeView(requireContext()).apply {
             setContent {

--- a/app/src/main/java/com/github/yuukis/businessmap/app/ContactsItemsDialogFragment.kt
+++ b/app/src/main/java/com/github/yuukis/businessmap/app/ContactsItemsDialogFragment.kt
@@ -36,6 +36,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.unit.dp
+import androidx.core.os.BundleCompat
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.FragmentActivity
 import com.github.yuukis.businessmap.R
@@ -60,7 +61,9 @@ class ContactsItemsDialogFragment : DialogFragment() {
         val args = arguments
         if (args != null && args.containsKey(KEY_CONTACTS_ITEMS)) {
             @Suppress("UNCHECKED_CAST")
-            contactsItems = args.get(KEY_CONTACTS_ITEMS) as? List<ContactsItem>
+            contactsItems = BundleCompat.getSerializable(
+                args, KEY_CONTACTS_ITEMS, Serializable::class.java
+            ) as? List<ContactsItem>
         }
     }
 

--- a/app/src/main/java/com/github/yuukis/businessmap/app/IncomingShortcutActivity.kt
+++ b/app/src/main/java/com/github/yuukis/businessmap/app/IncomingShortcutActivity.kt
@@ -60,6 +60,10 @@ class IncomingShortcutActivity : FragmentActivity(), ContactsGroupDialogFragment
             .setIntent(shortcutIntent)
             .build()
         val shortcutManager = getSystemService(ShortcutManager::class.java)
+        if (shortcutManager == null) {
+            setResult(RESULT_CANCELED, null)
+            return
+        }
 
         setResult(RESULT_OK, shortcutManager.createShortcutResultIntent(shortcutInfo))
     }

--- a/app/src/main/java/com/github/yuukis/businessmap/app/IncomingShortcutActivity.kt
+++ b/app/src/main/java/com/github/yuukis/businessmap/app/IncomingShortcutActivity.kt
@@ -18,6 +18,9 @@
 package com.github.yuukis.businessmap.app
 
 import android.content.Intent
+import android.content.pm.ShortcutInfo
+import android.content.pm.ShortcutManager
+import android.graphics.drawable.Icon
 import android.os.Bundle
 import androidx.fragment.app.FragmentActivity
 import com.github.yuukis.businessmap.R
@@ -47,19 +50,17 @@ class IncomingShortcutActivity : FragmentActivity(), ContactsGroupDialogFragment
         }
 
         val shortcutIntent = Intent(applicationContext, MainActivity::class.java)
+        shortcutIntent.action = Intent.ACTION_VIEW
         shortcutIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
         shortcutIntent.putExtra(MainActivity.KEY_CONTACTS_GROUP_ID, groupId)
 
-        val intent = Intent()
-        intent.putExtra(Intent.EXTRA_SHORTCUT_INTENT, shortcutIntent)
-        val iconResource = Intent.ShortcutIconResource.fromContext(
-            applicationContext, R.drawable.ic_launcher
-        )
-        // ホーム画面に設置した場合に表示されるアイコンの設定
-        intent.putExtra(Intent.EXTRA_SHORTCUT_ICON_RESOURCE, iconResource)
-        // ホーム画面に設置した場合に表示されるラベル名の設定
-        intent.putExtra(Intent.EXTRA_SHORTCUT_NAME, shortcutTitle)
+        val shortcutInfo = ShortcutInfo.Builder(this, "contacts_group_$groupId")
+            .setShortLabel(shortcutTitle)
+            .setIcon(Icon.createWithResource(applicationContext, R.drawable.ic_launcher))
+            .setIntent(shortcutIntent)
+            .build()
+        val shortcutManager = getSystemService(ShortcutManager::class.java)
 
-        setResult(RESULT_OK, intent)
+        setResult(RESULT_OK, shortcutManager.createShortcutResultIntent(shortcutInfo))
     }
 }

--- a/app/src/main/java/com/github/yuukis/businessmap/data/MapStatePreferences.kt
+++ b/app/src/main/java/com/github/yuukis/businessmap/data/MapStatePreferences.kt
@@ -22,7 +22,6 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.content.SharedPreferences
 import android.content.pm.PackageManager
-import android.location.Criteria
 import android.location.LocationManager
 import androidx.core.content.ContextCompat
 import com.google.android.gms.maps.model.CameraPosition
@@ -77,11 +76,7 @@ class MapStatePreferences(private val context: Context) {
 
         if (hasLocationPermission()) {
             val manager = context.getSystemService(Context.LOCATION_SERVICE) as LocationManager
-            val criteria = Criteria()
-            criteria.accuracy = Criteria.ACCURACY_FINE
-            manager.getBestProvider(criteria, true)
-            val provider = LocationManager.NETWORK_PROVIDER
-            val location = manager.getLastKnownLocation(provider)
+            val location = manager.getLastKnownLocation(LocationManager.NETWORK_PROVIDER)
             if (location != null) {
                 lat = location.latitude
                 lng = location.longitude

--- a/app/src/main/java/com/github/yuukis/businessmap/util/GeocoderUtils.kt
+++ b/app/src/main/java/com/github/yuukis/businessmap/util/GeocoderUtils.kt
@@ -1,7 +1,11 @@
 package com.github.yuukis.businessmap.util
 
 import android.content.Context
+import android.location.Address
 import android.location.Geocoder
+import android.os.Build
+import androidx.annotation.RequiresApi
+import kotlinx.coroutines.suspendCancellableCoroutine
 import org.json.JSONArray
 import org.json.JSONException
 import org.json.JSONObject
@@ -10,27 +14,53 @@ import java.net.HttpURLConnection
 import java.net.URL
 import java.net.URLEncoder
 import java.util.Locale
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
 
 object GeocoderUtils {
 
     @JvmStatic
     @Throws(IOException::class, JSONException::class)
-    fun getFromLocationName(context: Context, address: String): Array<Double?> {
-        var lat = Double.NaN
-        var lng = Double.NaN
-
+    suspend fun getFromLocationName(context: Context, address: String): Array<Double?> {
         return try {
-            val list = Geocoder(context, Locale.getDefault()).getFromLocationName(address, 1)
-            if (list != null && list.isNotEmpty()) {
-                val addr = list[0]
-                lat = addr.latitude
-                lng = addr.longitude
+            val list = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                getFromLocationNameAsync(context, address)
+            } else {
+                getFromLocationNameSync(context, address)
+            }
+            var lat = Double.NaN
+            var lng = Double.NaN
+            if (!list.isNullOrEmpty()) {
+                lat = list[0].latitude
+                lng = list[0].longitude
             }
             arrayOf(lat, lng)
         } catch (e: IOException) {
             getFromLocationNameToGoogleMaps(address)
         }
     }
+
+    @Suppress("DEPRECATION")
+    private fun getFromLocationNameSync(context: Context, address: String): List<Address>? =
+        Geocoder(context, Locale.getDefault()).getFromLocationName(address, 1)
+
+    @RequiresApi(Build.VERSION_CODES.TIRAMISU)
+    private suspend fun getFromLocationNameAsync(context: Context, address: String): List<Address> =
+        suspendCancellableCoroutine { cont ->
+            Geocoder(context, Locale.getDefault()).getFromLocationName(
+                address,
+                1,
+                object : Geocoder.GeocodeListener {
+                    override fun onGeocode(addresses: MutableList<Address>) {
+                        cont.resume(addresses)
+                    }
+
+                    override fun onError(errorMessage: String?) {
+                        cont.resumeWithException(IOException(errorMessage))
+                    }
+                }
+            )
+        }
 
     @Throws(IOException::class, JSONException::class)
     private fun getFromLocationNameToGoogleMaps(address: String): Array<Double?> {

--- a/app/src/main/java/com/github/yuukis/businessmap/util/GeocoderUtils.kt
+++ b/app/src/main/java/com/github/yuukis/businessmap/util/GeocoderUtils.kt
@@ -52,11 +52,15 @@ object GeocoderUtils {
                 1,
                 object : Geocoder.GeocodeListener {
                     override fun onGeocode(addresses: MutableList<Address>) {
-                        cont.resume(addresses)
+                        if (cont.isActive) {
+                            cont.resume(addresses)
+                        }
                     }
 
                     override fun onError(errorMessage: String?) {
-                        cont.resumeWithException(IOException(errorMessage))
+                        if (cont.isActive) {
+                            cont.resumeWithException(IOException(errorMessage ?: "Geocoding failed"))
+                        }
                     }
                 }
             )

--- a/app/src/main/java/com/github/yuukis/businessmap/view/OnInfoWindowElemTouchListener.kt
+++ b/app/src/main/java/com/github/yuukis/businessmap/view/OnInfoWindowElemTouchListener.kt
@@ -6,8 +6,8 @@
 package com.github.yuukis.businessmap.view
 
 import android.graphics.drawable.Drawable
-import android.os.Build
 import android.os.Handler
+import android.os.Looper
 import android.view.MotionEvent
 import android.view.View
 import com.google.android.gms.maps.model.Marker
@@ -18,7 +18,7 @@ abstract class OnInfoWindowElemTouchListener(
     private val bgDrawablePressed: Drawable
 ) : View.OnTouchListener {
 
-    private val handler = Handler()
+    private val handler = Handler(Looper.getMainLooper())
 
     private var marker: Marker? = null
     private var pressed = false
@@ -66,14 +66,8 @@ abstract class OnInfoWindowElemTouchListener(
         }
     }
 
-    @Suppress("DEPRECATION")
     private fun setBackground(drawable: Drawable) {
-        val sdk = Build.VERSION.SDK_INT
-        if (sdk < Build.VERSION_CODES.JELLY_BEAN) {
-            view.setBackgroundDrawable(drawable)
-        } else {
-            view.background = drawable
-        }
+        view.background = drawable
     }
 
     private val confirmClickRunnable = Runnable {


### PR DESCRIPTION
## Summary
- `minSdk`を24から26に引き上げ
- `Handler()`（Looper未指定コンストラクタ、API30で非推奨）を`Handler(Looper.getMainLooper())`に置き換え。minSdk26化により到達不能になった`OnInfoWindowElemTouchListener`内のJELLY_BEAN分岐も削除
- `IncomingShortcutActivity`のショートカット作成を、非推奨な`Intent.EXTRA_SHORTCUT_*`の生Extraから`ShortcutManager.createShortcutResultIntent`に置き換え（ランチャー側のCREATE_SHORTCUTピッカーからの起動・挙動は変更なし）
- `MapStatePreferences`の未使用だった`Criteria`/`getBestProvider`呼び出し（戻り値が使われておらず、常にNETWORK_PROVIDERが使われていた死んだコード）を削除。挙動は変わらない
- `GeocoderUtils`の同期版`Geocoder.getFromLocationName`（API33で非推奨）について、API33以上では`GeocodeListener`版を`suspendCancellableCoroutine`でラップして使用し、それ未満では従来の同期APIにフォールバック
- `Bundle.getSerializable(String)`/`Bundle.get(String)`（API33で非推奨）を型安全な`BundleCompat.getSerializable(Bundle, String, Class)`に置き換え

## Test plan
- [x] `./gradlew :app:assembleDebug` がビルド成功
- [x] `./gradlew :app:compileDebugKotlin` の出力に非推奨API警告が0件であることを確認
- [x] `./gradlew :app:testDebugUnitTest` が成功
- [x] `./gradlew :app:lintDebug` が成功（NewApiエラーなし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)