### PR TITLE
ショートカットアイコンを連絡先グループ名の頭文字にする

### DIFF
--- a/app/src/main/java/com/github/yuukis/businessmap/app/IncomingShortcutActivity.kt
+++ b/app/src/main/java/com/github/yuukis/businessmap/app/IncomingShortcutActivity.kt
@@ -25,6 +25,7 @@ import android.os.Bundle
 import androidx.fragment.app.FragmentActivity
 import com.github.yuukis.businessmap.R
 import com.github.yuukis.businessmap.model.ContactsGroup
+import com.github.yuukis.businessmap.util.IconUtils
 
 class IncomingShortcutActivity : FragmentActivity(), ContactsGroupDialogFragment.OnSelectListener {
 
@@ -54,9 +55,10 @@ class IncomingShortcutActivity : FragmentActivity(), ContactsGroupDialogFragment
         shortcutIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
         shortcutIntent.putExtra(MainActivity.KEY_CONTACTS_GROUP_ID, groupId)
 
+        val iconBitmap = IconUtils.createInitialIconBitmap(shortcutTitle)
         val shortcutInfo = ShortcutInfo.Builder(this, "contacts_group_$groupId")
             .setShortLabel(shortcutTitle)
-            .setIcon(Icon.createWithResource(applicationContext, R.drawable.ic_launcher))
+            .setIcon(Icon.createWithBitmap(iconBitmap))
             .setIntent(shortcutIntent)
             .build()
         val shortcutManager = getSystemService(ShortcutManager::class.java)

--- a/app/src/main/java/com/github/yuukis/businessmap/app/IncomingShortcutActivity.kt
+++ b/app/src/main/java/com/github/yuukis/businessmap/app/IncomingShortcutActivity.kt
@@ -55,7 +55,7 @@ class IncomingShortcutActivity : FragmentActivity(), ContactsGroupDialogFragment
         shortcutIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
         shortcutIntent.putExtra(MainActivity.KEY_CONTACTS_GROUP_ID, groupId)
 
-        val iconBitmap = IconUtils.createInitialIconBitmap(shortcutTitle)
+        val iconBitmap = IconUtils.createInitialIconBitmap(this, shortcutTitle)
         val shortcutInfo = ShortcutInfo.Builder(this, "contacts_group_$groupId")
             .setShortLabel(shortcutTitle)
             .setIcon(Icon.createWithBitmap(iconBitmap))

--- a/app/src/main/java/com/github/yuukis/businessmap/util/IconUtils.kt
+++ b/app/src/main/java/com/github/yuukis/businessmap/util/IconUtils.kt
@@ -17,33 +17,38 @@
  */
 package com.github.yuukis.businessmap.util
 
+import android.content.Context
+import android.content.pm.ShortcutManager
 import android.graphics.Bitmap
 import android.graphics.Canvas
 import android.graphics.Color
 import android.graphics.Paint
 import android.graphics.Typeface
+import java.util.Locale
 
 object IconUtils {
 
-    private const val ICON_SIZE = 192
-    private const val BACKGROUND_COLOR = "#3F51B5"
+    // Fallback used when ShortcutManager is unavailable (e.g. feature not supported).
+    private const val FALLBACK_ICON_SIZE_DP = 108
+    private val BACKGROUND_COLOR = Color.parseColor("#3F51B5")
 
     @JvmStatic
-    fun createInitialIconBitmap(label: String?): Bitmap {
-        val initial = label?.trim()?.firstOrNull()?.toString()?.uppercase() ?: "?"
+    fun createInitialIconBitmap(context: Context, label: String?): Bitmap {
+        val initial = label?.trim()?.firstOrNull()?.toString()?.uppercase(Locale.ROOT) ?: "?"
+        val iconSize = resolveIconSizePx(context)
 
-        val bitmap = Bitmap.createBitmap(ICON_SIZE, ICON_SIZE, Bitmap.Config.ARGB_8888)
+        val bitmap = Bitmap.createBitmap(iconSize, iconSize, Bitmap.Config.ARGB_8888)
         val canvas = Canvas(bitmap)
 
         val backgroundPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
-            color = Color.parseColor(BACKGROUND_COLOR)
+            color = BACKGROUND_COLOR
         }
-        val radius = ICON_SIZE / 2f
+        val radius = iconSize / 2f
         canvas.drawCircle(radius, radius, radius, backgroundPaint)
 
         val textPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
             color = Color.WHITE
-            textSize = ICON_SIZE * 0.5f
+            textSize = iconSize * 0.5f
             textAlign = Paint.Align.CENTER
             typeface = Typeface.DEFAULT_BOLD
         }
@@ -51,5 +56,16 @@ object IconUtils {
         canvas.drawText(initial, radius, textY, textPaint)
 
         return bitmap
+    }
+
+    private fun resolveIconSizePx(context: Context): Int {
+        val shortcutManager = context.getSystemService(ShortcutManager::class.java)
+        val maxWidth = shortcutManager?.iconMaxWidth ?: 0
+        val maxHeight = shortcutManager?.iconMaxHeight ?: 0
+        if (maxWidth > 0 && maxHeight > 0) {
+            return minOf(maxWidth, maxHeight)
+        }
+        val density = context.resources.displayMetrics.density
+        return (FALLBACK_ICON_SIZE_DP * density).toInt()
     }
 }

--- a/app/src/main/java/com/github/yuukis/businessmap/util/IconUtils.kt
+++ b/app/src/main/java/com/github/yuukis/businessmap/util/IconUtils.kt
@@ -1,0 +1,55 @@
+/*
+ * IconUtils.kt
+ *
+ * Copyright 2025 Yuuki Shimizu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.yuukis.businessmap.util
+
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.Paint
+import android.graphics.Typeface
+
+object IconUtils {
+
+    private const val ICON_SIZE = 192
+    private const val BACKGROUND_COLOR = "#3F51B5"
+
+    @JvmStatic
+    fun createInitialIconBitmap(label: String?): Bitmap {
+        val initial = label?.trim()?.firstOrNull()?.toString()?.uppercase() ?: "?"
+
+        val bitmap = Bitmap.createBitmap(ICON_SIZE, ICON_SIZE, Bitmap.Config.ARGB_8888)
+        val canvas = Canvas(bitmap)
+
+        val backgroundPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+            color = Color.parseColor(BACKGROUND_COLOR)
+        }
+        val radius = ICON_SIZE / 2f
+        canvas.drawCircle(radius, radius, radius, backgroundPaint)
+
+        val textPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+            color = Color.WHITE
+            textSize = ICON_SIZE * 0.5f
+            textAlign = Paint.Align.CENTER
+            typeface = Typeface.DEFAULT_BOLD
+        }
+        val textY = radius - (textPaint.descent() + textPaint.ascent()) / 2f
+        canvas.drawText(initial, radius, textY, textPaint)
+
+        return bitmap
+    }
+}


### PR DESCRIPTION
## Summary
- ショートカット登録時に表示するアイコンを、連絡先グループ名の頭文字を描いた円形アイコンとして動的生成するように変更
- 生成処理は `IconUtils.createInitialIconBitmap` に切り出し、`IncomingShortcutActivity` から利用

## Test plan
- [x] `./gradlew :app:compileDebugKotlin` が成功することを確認
- [x] 実機/エミュレータで連絡先グループのショートカットを作成し、頭文字アイコンが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)