### PR TITLE
Android Test Orchestrator実行時の断続クラッシュを解消

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -30,7 +30,6 @@ android {
             localProperties.getProperty("MAPS_API_KEY", "")
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-        testInstrumentationRunnerArguments["clearPackageData"] = "true"
     }
 
     testOptions {

--- a/app/src/androidTest/java/com/github/yuukis/businessmap/app/ContactsGroupDialogFragmentTest.kt
+++ b/app/src/androidTest/java/com/github/yuukis/businessmap/app/ContactsGroupDialogFragmentTest.kt
@@ -3,11 +3,11 @@ package com.github.yuukis.businessmap.app
 import androidx.compose.ui.test.junit4.createEmptyComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
-import androidx.lifecycle.Lifecycle
 import androidx.test.core.app.ActivityScenario
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.github.yuukis.businessmap.R
+import com.github.yuukis.businessmap.model.ContactsGroup
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Rule
@@ -28,9 +28,10 @@ class ContactsGroupDialogFragmentTest {
     }
 
     @Test
-    fun showsAllContactsGroupAndSelectingItFinishesTheActivity() {
-        ActivityScenario.launch(IncomingShortcutActivity::class.java).use { scenario ->
+    fun showsAllContactsGroupAndSelectingItNotifiesListenerAndDismissesTheDialog() {
+        ActivityScenario.launch(FakeContactsGroupSelectListenerActivity::class.java).use { scenario ->
             scenario.onActivity { activity ->
+                ContactsGroupDialogFragment.showDialog(activity)
                 activity.supportFragmentManager.executePendingTransactions()
             }
             composeTestRule.waitForIdle()
@@ -38,13 +39,14 @@ class ContactsGroupDialogFragmentTest {
             val allContactsLabel = targetContext.getString(R.string.group_all_contacts)
             composeTestRule.onNodeWithText(allContactsLabel).assertExists()
             composeTestRule.onNodeWithText(allContactsLabel).performClick()
+            composeTestRule.waitForIdle()
 
-            // finish() drives the activity to DESTROYED asynchronously via the system process;
-            // waitForIdle() only settles Compose, so poll instead of asserting immediately.
-            composeTestRule.waitUntil(timeoutMillis = 5_000) {
-                scenario.state == Lifecycle.State.DESTROYED
+            composeTestRule.onNodeWithText(allContactsLabel).assertDoesNotExist()
+
+            scenario.onActivity { activity ->
+                assertEquals(1, activity.selectionCallbackCount)
+                assertEquals(ContactsGroup.ID_GROUP_ALL_CONTACTS, activity.selectedGroup?.id)
             }
-            assertEquals(Lifecycle.State.DESTROYED, scenario.state)
         }
     }
 }

--- a/app/src/androidTest/java/com/github/yuukis/businessmap/app/MainActivityPermissionTest.kt
+++ b/app/src/androidTest/java/com/github/yuukis/businessmap/app/MainActivityPermissionTest.kt
@@ -4,14 +4,20 @@ import androidx.lifecycle.Lifecycle
 import androidx.test.core.app.ActivityScenario
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.Assert.assertTrue
+import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
 class MainActivityPermissionTest {
 
+    @Before
+    fun grantRuntimePermissions() {
+        TestPermissions.grantContactsAndLocation()
+    }
+
     @Test
-    fun launchesWithoutCrashingWhenPermissionsAreMissing() {
+    fun launchesWithoutCrashingWhenPermissionsAreReportedMissing() {
         ActivityScenario.launch(FakeMissingPermissionsMainActivity::class.java).use { scenario ->
             assertTrue(scenario.state.isAtLeast(Lifecycle.State.STARTED))
         }

--- a/app/src/androidTest/java/com/github/yuukis/businessmap/app/MainActivityPermissionTest.kt
+++ b/app/src/androidTest/java/com/github/yuukis/businessmap/app/MainActivityPermissionTest.kt
@@ -4,21 +4,15 @@ import androidx.lifecycle.Lifecycle
 import androidx.test.core.app.ActivityScenario
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.Assert.assertTrue
-import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
 class MainActivityPermissionTest {
 
-    @Before
-    fun revokeRuntimePermissions() {
-        TestPermissions.revokeContactsAndLocation()
-    }
-
     @Test
     fun launchesWithoutCrashingWhenPermissionsAreMissing() {
-        ActivityScenario.launch(MainActivity::class.java).use { scenario ->
+        ActivityScenario.launch(FakeMissingPermissionsMainActivity::class.java).use { scenario ->
             assertTrue(scenario.state.isAtLeast(Lifecycle.State.STARTED))
         }
     }

--- a/app/src/androidTest/java/com/github/yuukis/businessmap/app/TestPermissions.kt
+++ b/app/src/androidTest/java/com/github/yuukis/businessmap/app/TestPermissions.kt
@@ -24,16 +24,6 @@ internal object TestPermissions {
         }
     }
 
-    /**
-     * See grantContactsAndLocation(). Call this from @After so each test
-     * leaves the process in a clean state for whichever test runs next.
-     */
-    fun revokeContactsAndLocation() {
-        forEachPermission { permission ->
-            uiAutomation().revokeRuntimePermission(packageName(), permission)
-        }
-    }
-
     private fun forEachPermission(action: (String) -> Unit) {
         for (permission in listOf(
             Manifest.permission.READ_CONTACTS,

--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -16,6 +16,9 @@
             android:name="com.github.yuukis.businessmap.app.FakeMissingPermissionsMainActivity"
             android:exported="false" />
         <activity
+            android:name="com.github.yuukis.businessmap.app.FakeContactsGroupSelectListenerActivity"
+            android:exported="false" />
+        <activity
             android:name="com.github.yuukis.businessmap.app.FakeContactsSelectListenerActivity"
             android:exported="false" />
         <activity

--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -13,6 +13,9 @@
     -->
     <application>
         <activity
+            android:name="com.github.yuukis.businessmap.app.FakeMissingPermissionsMainActivity"
+            android:exported="false" />
+        <activity
             android:name="com.github.yuukis.businessmap.app.FakeContactsSelectListenerActivity"
             android:exported="false" />
         <activity

--- a/app/src/debug/java/com/github/yuukis/businessmap/app/FakeContactsGroupSelectListenerActivity.kt
+++ b/app/src/debug/java/com/github/yuukis/businessmap/app/FakeContactsGroupSelectListenerActivity.kt
@@ -1,0 +1,27 @@
+package com.github.yuukis.businessmap.app
+
+import androidx.fragment.app.FragmentActivity
+import com.github.yuukis.businessmap.model.ContactsGroup
+
+/**
+ * Minimal test-only host for [ContactsGroupDialogFragment].
+ *
+ * Keeping the fragment test independent from [IncomingShortcutActivity] avoids
+ * finishing the task under test, which can race Android Test Orchestrator's
+ * package cleanup between tests.
+ */
+class FakeContactsGroupSelectListenerActivity :
+    FragmentActivity(),
+    ContactsGroupDialogFragment.OnSelectListener {
+
+    var selectedGroup: ContactsGroup? = null
+        private set
+
+    var selectionCallbackCount: Int = 0
+        private set
+
+    override fun onContactsGroupSelected(group: ContactsGroup?) {
+        selectedGroup = group
+        selectionCallbackCount++
+    }
+}

--- a/app/src/debug/java/com/github/yuukis/businessmap/app/FakeMissingPermissionsMainActivity.kt
+++ b/app/src/debug/java/com/github/yuukis/businessmap/app/FakeMissingPermissionsMainActivity.kt
@@ -1,0 +1,10 @@
+package com.github.yuukis.businessmap.app
+
+/**
+ * Runs [MainActivity]'s real startup path while reporting every runtime
+ * permission as missing, regardless of permission state left by another test.
+ */
+class FakeMissingPermissionsMainActivity : MainActivity() {
+
+    override fun isPermissionGranted(permission: String): Boolean = false
+}

--- a/app/src/main/java/com/github/yuukis/businessmap/app/MainActivity.kt
+++ b/app/src/main/java/com/github/yuukis/businessmap/app/MainActivity.kt
@@ -101,7 +101,7 @@ import com.github.yuukis.businessmap.widget.MapWrapperLayout
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import kotlinx.coroutines.launch
 
-class MainActivity : AppCompatActivity(),
+open class MainActivity : AppCompatActivity(),
     ProgressDialogFragment.ProgressDialogFragmentListener,
     ContactsItemsDialogFragment.OnSelectListener {
 
@@ -142,8 +142,11 @@ class MainActivity : AppCompatActivity(),
     }
 
     private fun hasContactsPermission(): Boolean {
-        return ContextCompat.checkSelfPermission(this, Manifest.permission.READ_CONTACTS) ==
-            PackageManager.PERMISSION_GRANTED
+        return isPermissionGranted(Manifest.permission.READ_CONTACTS)
+    }
+
+    protected open fun isPermissionGranted(permission: String): Boolean {
+        return ContextCompat.checkSelfPermission(this, permission) == PackageManager.PERMISSION_GRANTED
     }
 
     private fun requestMissingPermissions() {
@@ -151,9 +154,7 @@ class MainActivity : AppCompatActivity(),
         if (!hasContactsPermission()) {
             missing.add(Manifest.permission.READ_CONTACTS)
         }
-        if (ContextCompat.checkSelfPermission(this, Manifest.permission.ACCESS_FINE_LOCATION) !=
-            PackageManager.PERMISSION_GRANTED
-        ) {
+        if (!isPermissionGranted(Manifest.permission.ACCESS_FINE_LOCATION)) {
             missing.add(Manifest.permission.ACCESS_FINE_LOCATION)
             missing.add(Manifest.permission.ACCESS_COARSE_LOCATION)
         }


### PR DESCRIPTION
## 概要

Android Test Orchestratorのフルスイート実行時に、アプリプロセスが `remove task` で断続的に終了する問題を解消します。

## 変更内容

- `clearPackageData=true` を削除し、テスト間の高速なデータクリアとプロセス再起動の競合を回避
- 権限未許可ケースを、実際の権限revokeではなくデバッグ専用Activityへの権限状態注入で検証
- `ContactsGroupDialogFragmentTest` を専用ホストActivityで実行し、グループ選択通知とダイアログ終了を直接検証
- 不要になったテスト用権限revoke処理を削除

## 確認結果

- `./gradlew :app:testDebugUnitTest :app:compileDebugAndroidTestKotlin`
- Pixel 7a（プレビューOS）で `./gradlew connectedAndroidTest` を3回連続実行
  - 3回とも11/11テスト成功

Closes #68