### PR TITLE
ContactsActionFragmentのIntent発火テストを追加

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -115,6 +115,7 @@ dependencies {
     androidTestImplementation(libs.androidx.test.runner)
     androidTestImplementation(libs.androidx.test.core)
     androidTestImplementation(libs.androidx.test.espresso.core)
+    androidTestImplementation(libs.androidx.test.espresso.intents)
     androidTestImplementation(libs.androidx.compose.ui.test.junit4)
     debugImplementation(libs.androidx.compose.ui.test.manifest)
     androidTestUtil(libs.androidx.test.orchestrator)

--- a/app/src/androidTest/java/com/github/yuukis/businessmap/app/ContactsActionFragmentTest.kt
+++ b/app/src/androidTest/java/com/github/yuukis/businessmap/app/ContactsActionFragmentTest.kt
@@ -1,13 +1,29 @@
 package com.github.yuukis.businessmap.app
 
+import android.app.Activity
+import android.app.Instrumentation.ActivityResult
+import android.content.ComponentName
+import android.content.Intent
+import android.net.Uri
+import android.provider.ContactsContract
 import androidx.compose.ui.test.junit4.createEmptyComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.test.core.app.ActivityScenario
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.espresso.intent.Intents
+import androidx.test.espresso.intent.Intents.intended
+import androidx.test.espresso.intent.Intents.intending
+import androidx.test.espresso.intent.matcher.IntentMatchers.anyIntent
+import androidx.test.espresso.intent.matcher.IntentMatchers.hasAction
+import androidx.test.espresso.intent.matcher.IntentMatchers.hasComponent
+import androidx.test.espresso.intent.matcher.IntentMatchers.hasData
+import androidx.test.espresso.intent.matcher.IntentMatchers.hasPackage
 import androidx.test.platform.app.InstrumentationRegistry
 import com.github.yuukis.businessmap.R
 import com.github.yuukis.businessmap.model.ContactsItem
+import org.hamcrest.Matcher
+import org.hamcrest.Matchers.allOf
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -34,7 +50,10 @@ class ContactsActionFragmentTest {
         address = "Tokyo",
         note = null,
         companyName = "ACME"
-    )
+    ).apply {
+        setLat(35.681236)
+        setLng(139.767125)
+    }
 
     @Test
     fun showsContactNameAndActionItems() {
@@ -54,19 +73,75 @@ class ContactsActionFragmentTest {
     }
 
     @Test
-    fun clickingShowContactsDismissesTheDialog() {
+    fun clickingShowContactsStartsContactViewIntent() {
+        verifyActionIntent(
+            R.string.action_contacts_detail,
+            allOf(
+                hasAction(Intent.ACTION_VIEW),
+                hasData(Uri.withAppendedPath(ContactsContract.Contacts.CONTENT_URI, "1"))
+            )
+        )
+    }
+
+    @Test
+    fun clickingDirectionsStartsMapsDirectionsIntent() {
+        verifyActionIntent(
+            R.string.action_directions,
+            allOf(
+                hasAction(Intent.ACTION_VIEW),
+                hasData(Uri.parse("http://maps.google.com/maps?saddr=&daddr=35.681236,139.767125"))
+            )
+        )
+    }
+
+    @Test
+    fun clickingDriveNavigationStartsGoogleMapsNavigationIntent() {
+        verifyActionIntent(
+            R.string.action_drive_navigation,
+            allOf(
+                hasAction(Intent.ACTION_VIEW),
+                hasData(Uri.parse("google.navigation:///?ll=35.681236,139.767125&q=Taro Yamada")),
+                hasComponent(
+                    ComponentName(
+                        "com.google.android.apps.maps",
+                        "com.google.android.maps.driveabout.app.NavigationActivity"
+                    )
+                )
+            )
+        )
+    }
+
+    @Test
+    fun clickingStreetViewStartsGoogleMapsStreetViewIntent() {
+        verifyActionIntent(
+            R.string.action_street_view,
+            allOf(
+                hasAction(Intent.ACTION_VIEW),
+                hasData(Uri.parse("google.streetview:cbll=35.681236,139.767125")),
+                hasPackage("com.google.android.apps.maps")
+            )
+        )
+    }
+
+    private fun verifyActionIntent(labelId: Int, intentMatcher: Matcher<Intent>) {
         ActivityScenario.launch(MainActivity::class.java).use { scenario ->
-            scenario.onActivity { activity ->
-                ContactsActionFragment.showDialog(activity, newContact())
-                activity.supportFragmentManager.executePendingTransactions()
+            Intents.init()
+            try {
+                intending(anyIntent()).respondWith(ActivityResult(Activity.RESULT_OK, null))
+
+                scenario.onActivity { activity ->
+                    ContactsActionFragment.showDialog(activity, newContact())
+                    activity.supportFragmentManager.executePendingTransactions()
+                }
+                composeTestRule.waitForIdle()
+
+                composeTestRule.onNodeWithText(targetContext.getString(labelId)).performClick()
+                composeTestRule.waitForIdle()
+
+                intended(intentMatcher)
+            } finally {
+                Intents.release()
             }
-            composeTestRule.waitForIdle()
-
-            val showContactsLabel = targetContext.getString(R.string.action_contacts_detail)
-            composeTestRule.onNodeWithText(showContactsLabel).performClick()
-            composeTestRule.waitForIdle()
-
-            composeTestRule.onNodeWithText(showContactsLabel).assertDoesNotExist()
         }
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,6 +25,7 @@ androidx-test-ext-junit = { group = "androidx.test.ext", name = "junit", version
 androidx-test-runner = { group = "androidx.test", name = "runner", version.ref = "androidxTestRunner" }
 androidx-test-core = { group = "androidx.test", name = "core", version.ref = "androidxTestCore" }
 androidx-test-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espresso" }
+androidx-test-espresso-intents = { group = "androidx.test.espresso", name = "espresso-intents", version.ref = "espresso" }
 androidx-test-orchestrator = { group = "androidx.test", name = "orchestrator", version.ref = "androidxTestOrchestrator" }
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
 androidx-activity-ktx = { group = "androidx.activity", name = "activity-ktx", version.ref = "activity" }


### PR DESCRIPTION
## 概要

`ContactsActionFragment` の各アクションをタップした際に、期待するIntentが発火することを検証するinstrumentation testを追加します。

## 変更内容

- Espresso IntentsをandroidTest依存に追加
- 連絡先表示のactionとcontact URIを検証
- 経路表示のactionとGoogle Maps URLを検証
- ドライブナビのaction、URI、componentを検証
- ストリートビューのaction、URI、packageを検証
- 外部Activity起動をスタブし、インストール済みアプリに依存しないテストに変更

## 確認結果

- Pixel 7aで `./gradlew connectedAndroidTest`
  - 14/14テスト成功
- `./gradlew testDebugUnitTest`
  - 成功

Closes #85