### PR TITLE
地図長押しで連絡先登録を支援する機能を追加 (#29)

### DIFF
--- a/app/src/androidTest/java/com/github/yuukis/businessmap/app/ContactsActionFragmentTest.kt
+++ b/app/src/androidTest/java/com/github/yuukis/businessmap/app/ContactsActionFragmentTest.kt
@@ -100,7 +100,7 @@ class ContactsActionFragmentTest {
             R.string.action_drive_navigation,
             allOf(
                 hasAction(Intent.ACTION_VIEW),
-                hasData(Uri.parse("google.navigation:///?ll=35.681236,139.767125&q=Taro Yamada")),
+                hasData(Uri.parse("google.navigation:///?ll=35.681236,139.767125&q=Taro%20Yamada")),
                 hasComponent(
                     ComponentName(
                         "com.google.android.apps.maps",

--- a/app/src/androidTest/java/com/github/yuukis/businessmap/app/LocationActionFragmentTest.kt
+++ b/app/src/androidTest/java/com/github/yuukis/businessmap/app/LocationActionFragmentTest.kt
@@ -1,12 +1,29 @@
 package com.github.yuukis.businessmap.app
 
+import android.app.Activity
+import android.app.Instrumentation.ActivityResult
+import android.content.ComponentName
+import android.content.Intent
+import android.net.Uri
+import android.provider.ContactsContract
 import androidx.compose.ui.test.junit4.createEmptyComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.test.core.app.ActivityScenario
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.espresso.intent.Intents
+import androidx.test.espresso.intent.Intents.intended
+import androidx.test.espresso.intent.Intents.intending
+import androidx.test.espresso.intent.matcher.IntentMatchers.anyIntent
+import androidx.test.espresso.intent.matcher.IntentMatchers.hasAction
+import androidx.test.espresso.intent.matcher.IntentMatchers.hasComponent
+import androidx.test.espresso.intent.matcher.IntentMatchers.hasData
+import androidx.test.espresso.intent.matcher.IntentMatchers.hasExtra
+import androidx.test.espresso.intent.matcher.IntentMatchers.hasPackage
 import androidx.test.platform.app.InstrumentationRegistry
 import com.github.yuukis.businessmap.R
+import org.hamcrest.Matcher
+import org.hamcrest.Matchers.allOf
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -20,6 +37,10 @@ class LocationActionFragmentTest {
 
     private val targetContext get() = InstrumentationRegistry.getInstrumentation().targetContext
 
+    private val lat = 35.681236
+    private val lng = 139.767125
+    private val address = "Tokyo"
+
     @Before
     fun grantRuntimePermissions() {
         TestPermissions.grantContactsAndLocation()
@@ -29,12 +50,12 @@ class LocationActionFragmentTest {
     fun showsAddressAndActionItems() {
         ActivityScenario.launch(MainActivity::class.java).use { scenario ->
             scenario.onActivity { activity ->
-                LocationActionFragment.showDialog(activity, 35.0, 139.0, "Tokyo")
+                LocationActionFragment.showDialog(activity, lat, lng, address)
                 activity.supportFragmentManager.executePendingTransactions()
             }
             composeTestRule.waitForIdle()
 
-            composeTestRule.onNodeWithText("Tokyo").assertExists()
+            composeTestRule.onNodeWithText(address).assertExists()
             composeTestRule.onNodeWithText(targetContext.getString(R.string.action_register_contact)).assertExists()
             composeTestRule.onNodeWithText(targetContext.getString(R.string.action_directions)).assertExists()
             composeTestRule.onNodeWithText(targetContext.getString(R.string.action_drive_navigation)).assertExists()
@@ -43,19 +64,76 @@ class LocationActionFragmentTest {
     }
 
     @Test
-    fun clickingRegisterContactDismissesTheDialog() {
+    fun clickingRegisterContactStartsContactInsertIntent() {
+        verifyActionIntent(
+            R.string.action_register_contact,
+            allOf(
+                hasAction(Intent.ACTION_INSERT),
+                hasData(ContactsContract.Contacts.CONTENT_URI),
+                hasExtra(ContactsContract.Intents.Insert.POSTAL, address)
+            )
+        )
+    }
+
+    @Test
+    fun clickingDirectionsStartsMapsDirectionsIntent() {
+        verifyActionIntent(
+            R.string.action_directions,
+            allOf(
+                hasAction(Intent.ACTION_VIEW),
+                hasData(Uri.parse("http://maps.google.com/maps?saddr=&daddr=35.681236,139.767125"))
+            )
+        )
+    }
+
+    @Test
+    fun clickingDriveNavigationStartsGoogleMapsNavigationIntent() {
+        verifyActionIntent(
+            R.string.action_drive_navigation,
+            allOf(
+                hasAction(Intent.ACTION_VIEW),
+                hasData(Uri.parse("google.navigation:///?ll=35.681236,139.767125&q=Tokyo")),
+                hasComponent(
+                    ComponentName(
+                        "com.google.android.apps.maps",
+                        "com.google.android.maps.driveabout.app.NavigationActivity"
+                    )
+                )
+            )
+        )
+    }
+
+    @Test
+    fun clickingStreetViewStartsGoogleMapsStreetViewIntent() {
+        verifyActionIntent(
+            R.string.action_street_view,
+            allOf(
+                hasAction(Intent.ACTION_VIEW),
+                hasData(Uri.parse("google.streetview:cbll=35.681236,139.767125")),
+                hasPackage("com.google.android.apps.maps")
+            )
+        )
+    }
+
+    private fun verifyActionIntent(labelId: Int, intentMatcher: Matcher<Intent>) {
         ActivityScenario.launch(MainActivity::class.java).use { scenario ->
-            scenario.onActivity { activity ->
-                LocationActionFragment.showDialog(activity, 35.0, 139.0, "Tokyo")
-                activity.supportFragmentManager.executePendingTransactions()
+            Intents.init()
+            try {
+                intending(anyIntent()).respondWith(ActivityResult(Activity.RESULT_OK, null))
+
+                scenario.onActivity { activity ->
+                    LocationActionFragment.showDialog(activity, lat, lng, address)
+                    activity.supportFragmentManager.executePendingTransactions()
+                }
+                composeTestRule.waitForIdle()
+
+                composeTestRule.onNodeWithText(targetContext.getString(labelId)).performClick()
+                composeTestRule.waitForIdle()
+
+                intended(intentMatcher)
+            } finally {
+                Intents.release()
             }
-            composeTestRule.waitForIdle()
-
-            val registerContactLabel = targetContext.getString(R.string.action_register_contact)
-            composeTestRule.onNodeWithText(registerContactLabel).performClick()
-            composeTestRule.waitForIdle()
-
-            composeTestRule.onNodeWithText(registerContactLabel).assertDoesNotExist()
         }
     }
 }

--- a/app/src/androidTest/java/com/github/yuukis/businessmap/app/LocationActionFragmentTest.kt
+++ b/app/src/androidTest/java/com/github/yuukis/businessmap/app/LocationActionFragmentTest.kt
@@ -1,0 +1,61 @@
+package com.github.yuukis.businessmap.app
+
+import androidx.compose.ui.test.junit4.createEmptyComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.core.app.ActivityScenario
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.github.yuukis.businessmap.R
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class LocationActionFragmentTest {
+
+    @get:Rule
+    val composeTestRule = createEmptyComposeRule()
+
+    private val targetContext get() = InstrumentationRegistry.getInstrumentation().targetContext
+
+    @Before
+    fun grantRuntimePermissions() {
+        TestPermissions.grantContactsAndLocation()
+    }
+
+    @Test
+    fun showsAddressAndActionItems() {
+        ActivityScenario.launch(MainActivity::class.java).use { scenario ->
+            scenario.onActivity { activity ->
+                LocationActionFragment.showDialog(activity, 35.0, 139.0, "Tokyo")
+                activity.supportFragmentManager.executePendingTransactions()
+            }
+            composeTestRule.waitForIdle()
+
+            composeTestRule.onNodeWithText("Tokyo").assertExists()
+            composeTestRule.onNodeWithText(targetContext.getString(R.string.action_register_contact)).assertExists()
+            composeTestRule.onNodeWithText(targetContext.getString(R.string.action_directions)).assertExists()
+            composeTestRule.onNodeWithText(targetContext.getString(R.string.action_drive_navigation)).assertExists()
+            composeTestRule.onNodeWithText(targetContext.getString(R.string.action_street_view)).assertExists()
+        }
+    }
+
+    @Test
+    fun clickingRegisterContactDismissesTheDialog() {
+        ActivityScenario.launch(MainActivity::class.java).use { scenario ->
+            scenario.onActivity { activity ->
+                LocationActionFragment.showDialog(activity, 35.0, 139.0, "Tokyo")
+                activity.supportFragmentManager.executePendingTransactions()
+            }
+            composeTestRule.waitForIdle()
+
+            val registerContactLabel = targetContext.getString(R.string.action_register_contact)
+            composeTestRule.onNodeWithText(registerContactLabel).performClick()
+            composeTestRule.waitForIdle()
+
+            composeTestRule.onNodeWithText(registerContactLabel).assertDoesNotExist()
+        }
+    }
+}

--- a/app/src/main/java/com/github/yuukis/businessmap/app/ContactsMapFragment.kt
+++ b/app/src/main/java/com/github/yuukis/businessmap/app/ContactsMapFragment.kt
@@ -56,6 +56,7 @@ class ContactsMapFragment :
     GoogleMap.OnInfoWindowClickListener,
     GoogleMap.OnMapLongClickListener,
     GoogleMap.OnMapClickListener,
+    GoogleMap.OnMarkerClickListener,
     OnMapReadyCallback {
 
     private val viewModel: MainActivityViewModel by activityViewModels()
@@ -217,6 +218,17 @@ class ContactsMapFragment :
     }
 
     override fun onMapClick(latLng: LatLng) {
+        removeLongPressMarker()
+    }
+
+    override fun onMarkerClick(marker: Marker): Boolean {
+        if (marker != longPressMarker) {
+            removeLongPressMarker()
+        }
+        return false
+    }
+
+    private fun removeLongPressMarker() {
         longPressMarker?.remove()
         longPressMarker = null
         longPressAddress = null
@@ -232,6 +244,7 @@ class ContactsMapFragment :
         currentMap.setOnInfoWindowClickListener(this)
         currentMap.setOnMapLongClickListener(this)
         currentMap.setOnMapClickListener(this)
+        currentMap.setOnMarkerClickListener(this)
         currentMap.isIndoorEnabled = false
         if (hasLocationPermission()) {
             currentMap.isMyLocationEnabled = true

--- a/app/src/main/java/com/github/yuukis/businessmap/app/ContactsMapFragment.kt
+++ b/app/src/main/java/com/github/yuukis/businessmap/app/ContactsMapFragment.kt
@@ -30,9 +30,11 @@ import android.widget.Button
 import android.widget.TextView
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.activityViewModels
+import androidx.lifecycle.lifecycleScope
 import com.github.yuukis.businessmap.R
 import com.github.yuukis.businessmap.data.MapStatePreferences
 import com.github.yuukis.businessmap.model.ContactsItem
+import com.github.yuukis.businessmap.util.GeocoderUtils
 import com.github.yuukis.businessmap.view.OnInfoWindowElemTouchListener
 import com.github.yuukis.businessmap.widget.MapWrapperLayout
 import com.google.android.gms.maps.CameraUpdateFactory
@@ -45,9 +47,16 @@ import com.google.android.gms.maps.model.CameraPosition
 import com.google.android.gms.maps.model.LatLng
 import com.google.android.gms.maps.model.Marker
 import com.google.android.gms.maps.model.MarkerOptions
+import kotlinx.coroutines.launch
+import java.io.IOException
 import java.util.Locale
 
-class ContactsMapFragment : SupportMapFragment(), GoogleMap.OnInfoWindowClickListener, OnMapReadyCallback {
+class ContactsMapFragment :
+    SupportMapFragment(),
+    GoogleMap.OnInfoWindowClickListener,
+    GoogleMap.OnMapLongClickListener,
+    GoogleMap.OnMapClickListener,
+    OnMapReadyCallback {
 
     private val viewModel: MainActivityViewModel by activityViewModels()
 
@@ -60,6 +69,8 @@ class ContactsMapFragment : SupportMapFragment(), GoogleMap.OnInfoWindowClickLis
     private val markerContactHashMap = SparseArray<ContactsItem>()
     private val latlngContactsHashMap = SparseArray<MutableList<ContactsItem>>()
     private lateinit var preferences: MapStatePreferences
+    private var longPressMarker: Marker? = null
+    private var longPressAddress: String? = null
 
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
@@ -170,8 +181,48 @@ class ContactsMapFragment : SupportMapFragment(), GoogleMap.OnInfoWindowClickLis
     }
 
     override fun onInfoWindowClick(marker: Marker) {
+        if (marker == longPressMarker) {
+            val position = marker.position
+            LocationActionFragment.showDialog(requireActivity(), position.latitude, position.longitude, longPressAddress)
+            return
+        }
         val contact = markerContactHashMap[marker.hashCode()] ?: return
         ContactsActionFragment.showDialog(requireActivity(), contact)
+    }
+
+    override fun onMapLongClick(latLng: LatLng) {
+        val currentMap = map ?: return
+        longPressMarker?.remove()
+        longPressAddress = null
+
+        val marker = currentMap.addMarker(
+            MarkerOptions()
+                .position(latLng)
+                .title(getString(R.string.message_geocoding_address))
+        ) ?: return
+        longPressMarker = marker
+        marker.showInfoWindow()
+
+        viewLifecycleOwner.lifecycleScope.launch {
+            val address = try {
+                GeocoderUtils.getFromLocation(requireContext(), latLng.latitude, latLng.longitude)
+            } catch (e: IOException) {
+                ""
+            }
+            if (marker == longPressMarker) {
+                longPressAddress = address.ifEmpty { getString(R.string.message_no_data) }
+                marker.title = longPressAddress
+                if (marker.isInfoWindowShown) {
+                    marker.showInfoWindow()
+                }
+            }
+        }
+    }
+
+    override fun onMapClick(latLng: LatLng) {
+        longPressMarker?.remove()
+        longPressMarker = null
+        longPressAddress = null
     }
 
     private fun getContactsList(): List<ContactsItem>? = viewModel.currentGroupContactsList.value
@@ -182,6 +233,8 @@ class ContactsMapFragment : SupportMapFragment(), GoogleMap.OnInfoWindowClickLis
         val position = preferences.getCameraPosition()
         currentMap.setInfoWindowAdapter(MyInfoWindowAdapter())
         currentMap.setOnInfoWindowClickListener(this)
+        currentMap.setOnMapLongClickListener(this)
+        currentMap.setOnMapClickListener(this)
         currentMap.isIndoorEnabled = false
         if (hasLocationPermission()) {
             currentMap.isMyLocationEnabled = true
@@ -278,6 +331,18 @@ class ContactsMapFragment : SupportMapFragment(), GoogleMap.OnInfoWindowClickLis
             val btnOtherCount = infoButton
             val separator = view.findViewById<View>(R.id.separator)
             infoButtonListener?.setMarker(marker)
+
+            if (marker == longPressMarker) {
+                tvTitle.text = marker.title
+                tvCompanyName.visibility = View.GONE
+                tvSnippet.text = null
+                separator.visibility = View.GONE
+                tvNote.visibility = View.GONE
+                btnOtherCount?.visibility = View.GONE
+
+                mapWrapperLayout?.setMarkerWithInfoWindow(marker, view)
+                return view
+            }
 
             if (contacts != null) {
                 val title = marker.title

--- a/app/src/main/java/com/github/yuukis/businessmap/app/ContactsMapFragment.kt
+++ b/app/src/main/java/com/github/yuukis/businessmap/app/ContactsMapFragment.kt
@@ -193,8 +193,7 @@ class ContactsMapFragment :
 
     override fun onMapLongClick(latLng: LatLng) {
         val currentMap = map ?: return
-        longPressMarker?.remove()
-        longPressAddress = null
+        removeLongPressMarker()
 
         val marker = currentMap.addMarker(
             MarkerOptions()
@@ -345,7 +344,7 @@ class ContactsMapFragment :
             if (marker == longPressMarker) {
                 tvTitle.text = marker.title
                 tvCompanyName.visibility = View.GONE
-                tvSnippet.text = null
+                tvSnippet.visibility = View.GONE
                 separator.visibility = View.GONE
                 tvNote.visibility = View.GONE
                 btnOtherCount?.visibility = View.GONE
@@ -368,6 +367,7 @@ class ContactsMapFragment :
 
                 val snippet = marker.snippet?.replace("[ 　]".toRegex(), "\n")
                 tvSnippet.text = snippet
+                tvSnippet.visibility = View.VISIBLE
 
                 val note = contacts.note
                 if (TextUtils.isEmpty(note)) {

--- a/app/src/main/java/com/github/yuukis/businessmap/app/ContactsMapFragment.kt
+++ b/app/src/main/java/com/github/yuukis/businessmap/app/ContactsMapFragment.kt
@@ -49,7 +49,6 @@ import com.google.android.gms.maps.model.LatLng
 import com.google.android.gms.maps.model.Marker
 import com.google.android.gms.maps.model.MarkerOptions
 import kotlinx.coroutines.launch
-import java.io.IOException
 import java.util.Locale
 
 class ContactsMapFragment :
@@ -206,14 +205,10 @@ class ContactsMapFragment :
         marker.showInfoWindow()
 
         viewLifecycleOwner.lifecycleScope.launch {
-            val address = try {
-                GeocoderUtils.getFromLocation(requireContext(), latLng.latitude, latLng.longitude)
-            } catch (e: IOException) {
-                ""
-            }
+            val address = GeocoderUtils.getFromLocation(requireContext(), latLng.latitude, latLng.longitude)
             if (marker == longPressMarker) {
-                longPressAddress = address.ifEmpty { getString(R.string.message_no_data) }
-                marker.title = longPressAddress
+                longPressAddress = address
+                marker.title = address.ifEmpty { getString(R.string.message_geocoding_failed) }
                 if (marker.isInfoWindowShown) {
                     marker.showInfoWindow()
                 }

--- a/app/src/main/java/com/github/yuukis/businessmap/app/ContactsMapFragment.kt
+++ b/app/src/main/java/com/github/yuukis/businessmap/app/ContactsMapFragment.kt
@@ -43,6 +43,7 @@ import com.google.android.gms.maps.GoogleMap.CancelableCallback
 import com.google.android.gms.maps.GoogleMap.InfoWindowAdapter
 import com.google.android.gms.maps.OnMapReadyCallback
 import com.google.android.gms.maps.SupportMapFragment
+import com.google.android.gms.maps.model.BitmapDescriptorFactory
 import com.google.android.gms.maps.model.CameraPosition
 import com.google.android.gms.maps.model.LatLng
 import com.google.android.gms.maps.model.Marker
@@ -199,6 +200,7 @@ class ContactsMapFragment :
             MarkerOptions()
                 .position(latLng)
                 .title(getString(R.string.message_geocoding_address))
+                .icon(BitmapDescriptorFactory.defaultMarker(BitmapDescriptorFactory.HUE_GREEN))
         ) ?: return
         longPressMarker = marker
         marker.showInfoWindow()

--- a/app/src/main/java/com/github/yuukis/businessmap/app/LocationActionFragment.kt
+++ b/app/src/main/java/com/github/yuukis/businessmap/app/LocationActionFragment.kt
@@ -83,7 +83,8 @@ class LocationActionFragment : BottomSheetDialogFragment() {
                 AppTheme {
                     Surface {
                         LocationActionContent(
-                            address = address.orEmpty(),
+                            title = address?.ifEmpty { stringResource(R.string.label_selected_location) }
+                                ?: stringResource(R.string.label_selected_location),
                             onActionClick = ::onActionClick
                         )
                     }
@@ -96,7 +97,7 @@ class LocationActionFragment : BottomSheetDialogFragment() {
         val context = requireActivity()
 
         when (itemId) {
-            ID_REGISTER_CONTACT -> ActionUtils.doRegisterContact(context, lat, lng, address)
+            ID_REGISTER_CONTACT -> ActionUtils.doRegisterContact(context, address)
             ID_DIRECTION -> ActionUtils.doShowDirections(context, lat, lng)
             ID_NAVIGATION -> ActionUtils.doStartDriveNavigation(context, lat, lng, address.orEmpty())
             ID_STREETVIEW -> ActionUtils.doShowStreetView(context, lat, lng)
@@ -135,12 +136,12 @@ class LocationActionFragment : BottomSheetDialogFragment() {
 
 @Composable
 private fun LocationActionContent(
-    address: String,
+    title: String,
     onActionClick: (itemId: Int) -> Unit
 ) {
     Column(modifier = Modifier.padding(bottom = 16.dp)) {
         Text(
-            text = address,
+            text = title,
             style = MaterialTheme.typography.titleLarge,
             color = MaterialTheme.colorScheme.onSurface,
             modifier = Modifier.padding(start = 24.dp, top = 24.dp, end = 24.dp, bottom = 8.dp)

--- a/app/src/main/java/com/github/yuukis/businessmap/app/LocationActionFragment.kt
+++ b/app/src/main/java/com/github/yuukis/businessmap/app/LocationActionFragment.kt
@@ -1,0 +1,187 @@
+/*
+ * LocationActionFragment.kt
+ *
+ * Copyright 2013 Yuuki Shimizu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.yuukis.businessmap.app
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Directions
+import androidx.compose.material.icons.filled.Navigation
+import androidx.compose.material.icons.filled.PersonAdd
+import androidx.compose.material.icons.filled.Streetview
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.res.integerResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.fragment.app.FragmentActivity
+import com.github.yuukis.businessmap.R
+import com.github.yuukis.businessmap.util.ActionUtils
+import com.google.android.material.bottomsheet.BottomSheetDialogFragment
+
+private data class LocationActionItem(val itemId: Int, val icon: ImageVector, val titleId: Int)
+
+private val ACTION_ITEMS = listOf(
+    LocationActionItem(LocationActionFragment.ID_REGISTER_CONTACT, Icons.Default.PersonAdd, R.string.action_register_contact),
+    LocationActionItem(LocationActionFragment.ID_DIRECTION, Icons.Default.Directions, R.string.action_directions),
+    LocationActionItem(LocationActionFragment.ID_NAVIGATION, Icons.Default.Navigation, R.string.action_drive_navigation),
+    LocationActionItem(LocationActionFragment.ID_STREETVIEW, Icons.Default.Streetview, R.string.action_street_view)
+)
+
+class LocationActionFragment : BottomSheetDialogFragment() {
+
+    private var lat: Double = 0.0
+    private var lng: Double = 0.0
+    private var address: String? = null
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        val args = requireArguments()
+        lat = args.getDouble(KEY_LAT)
+        lng = args.getDouble(KEY_LNG)
+        address = args.getString(KEY_ADDRESS)
+
+        return ComposeView(requireContext()).apply {
+            setContent {
+                AppTheme {
+                    Surface {
+                        LocationActionContent(
+                            address = address.orEmpty(),
+                            onActionClick = ::onActionClick
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    private fun onActionClick(itemId: Int) {
+        val context = requireActivity()
+
+        when (itemId) {
+            ID_REGISTER_CONTACT -> ActionUtils.doRegisterContact(context, lat, lng, address)
+            ID_DIRECTION -> ActionUtils.doShowDirections(context, lat, lng)
+            ID_NAVIGATION -> ActionUtils.doStartDriveNavigation(context, lat, lng, address.orEmpty())
+            ID_STREETVIEW -> ActionUtils.doShowStreetView(context, lat, lng)
+        }
+        dismiss()
+    }
+
+    companion object {
+        private const val TAG = "LocationActionFragment"
+        private const val KEY_LAT = "lat"
+        private const val KEY_LNG = "lng"
+        private const val KEY_ADDRESS = "address"
+        const val ID_REGISTER_CONTACT = 1
+        const val ID_DIRECTION = 2
+        const val ID_NAVIGATION = 3
+        const val ID_STREETVIEW = 4
+
+        @JvmStatic
+        fun newInstance(lat: Double, lng: Double, address: String?): LocationActionFragment {
+            val fragment = LocationActionFragment()
+            val args = Bundle()
+            args.putDouble(KEY_LAT, lat)
+            args.putDouble(KEY_LNG, lng)
+            args.putString(KEY_ADDRESS, address)
+            fragment.arguments = args
+            return fragment
+        }
+
+        @JvmStatic
+        fun showDialog(activity: FragmentActivity, lat: Double, lng: Double, address: String?) {
+            val manager = activity.supportFragmentManager
+            newInstance(lat, lng, address).show(manager, TAG)
+        }
+    }
+}
+
+@Composable
+private fun LocationActionContent(
+    address: String,
+    onActionClick: (itemId: Int) -> Unit
+) {
+    Column(modifier = Modifier.padding(bottom = 16.dp)) {
+        Text(
+            text = address,
+            style = MaterialTheme.typography.titleLarge,
+            color = MaterialTheme.colorScheme.onSurface,
+            modifier = Modifier.padding(start = 24.dp, top = 24.dp, end = 24.dp, bottom = 8.dp)
+        )
+
+        val columns = integerResource(R.integer.gridview_columns)
+        LazyVerticalGrid(
+            columns = GridCells.Fixed(columns),
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            items(ACTION_ITEMS) { data ->
+                LocationActionGridItem(data = data, onClick = { onActionClick(data.itemId) })
+            }
+        }
+    }
+}
+
+@Composable
+private fun LocationActionGridItem(
+    data: LocationActionItem,
+    onClick: () -> Unit
+) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(112.dp)
+            .clickable(onClick = onClick)
+            .padding(horizontal = 8.dp)
+    ) {
+        Icon(
+            imageVector = data.icon,
+            contentDescription = stringResource(data.titleId),
+            tint = MaterialTheme.colorScheme.onSurface,
+            modifier = Modifier.size(64.dp)
+        )
+        Text(
+            text = stringResource(data.titleId),
+            color = MaterialTheme.colorScheme.onSurface,
+            style = MaterialTheme.typography.bodyLarge
+        )
+    }
+}

--- a/app/src/main/java/com/github/yuukis/businessmap/util/ActionUtils.kt
+++ b/app/src/main/java/com/github/yuukis/businessmap/util/ActionUtils.kt
@@ -22,7 +22,9 @@ import android.content.ContentUris
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
+import android.provider.ContactsContract.CommonDataKinds.StructuredPostal
 import android.provider.ContactsContract.Contacts
+import android.provider.ContactsContract.Intents
 import com.github.yuukis.businessmap.model.ContactsItem
 import java.util.Locale
 
@@ -37,11 +39,18 @@ object ActionUtils {
 
     @JvmStatic
     fun doShowDirections(context: Context, contact: ContactsItem) {
+        val lat = contact.lat ?: return
+        val lng = contact.lng ?: return
+        doShowDirections(context, lat, lng)
+    }
+
+    @JvmStatic
+    fun doShowDirections(context: Context, lat: Double, lng: Double) {
         val uri = Uri.parse(
             String.format(
                 Locale.US,
                 "http://maps.google.com/maps?saddr=&daddr=%f,%f",
-                contact.lat, contact.lng
+                lat, lng
             )
         )
         val intent = Intent(Intent.ACTION_VIEW, uri)
@@ -50,11 +59,18 @@ object ActionUtils {
 
     @JvmStatic
     fun doStartDriveNavigation(context: Context, contact: ContactsItem) {
+        val lat = contact.lat ?: return
+        val lng = contact.lng ?: return
+        doStartDriveNavigation(context, lat, lng, contact.name.orEmpty())
+    }
+
+    @JvmStatic
+    fun doStartDriveNavigation(context: Context, lat: Double, lng: Double, label: String) {
         val uri = Uri.parse(
             String.format(
                 Locale.US,
                 "google.navigation:///?ll=%f,%f&q=%s",
-                contact.lat, contact.lng, contact.name
+                lat, lng, label
             )
         )
         val intent = Intent(Intent.ACTION_VIEW, uri)
@@ -71,11 +87,18 @@ object ActionUtils {
 
     @JvmStatic
     fun doShowStreetView(context: Context, contact: ContactsItem) {
+        val lat = contact.lat ?: return
+        val lng = contact.lng ?: return
+        doShowStreetView(context, lat, lng)
+    }
+
+    @JvmStatic
+    fun doShowStreetView(context: Context, lat: Double, lng: Double) {
         val uri = Uri.parse(
             String.format(
                 Locale.US,
                 "google.streetview:cbll=%f,%f",
-                contact.lat, contact.lng
+                lat, lng
             )
         )
         val intent = Intent(Intent.ACTION_VIEW, uri)
@@ -84,6 +107,18 @@ object ActionUtils {
             context.startActivity(intent)
         } catch (e: ActivityNotFoundException) {
             // Google Maps is not installed; nothing we can do.
+        }
+    }
+
+    @JvmStatic
+    fun doRegisterContact(context: Context, lat: Double, lng: Double, address: String?) {
+        val intent = Intent(Intent.ACTION_INSERT, Contacts.CONTENT_URI)
+        intent.putExtra(Intents.Insert.POSTAL, address)
+        intent.putExtra(Intents.Insert.POSTAL_TYPE, StructuredPostal.TYPE_WORK)
+        try {
+            context.startActivity(intent)
+        } catch (e: ActivityNotFoundException) {
+            // No contacts app is available to handle the insert request.
         }
     }
 }

--- a/app/src/main/java/com/github/yuukis/businessmap/util/ActionUtils.kt
+++ b/app/src/main/java/com/github/yuukis/businessmap/util/ActionUtils.kt
@@ -70,7 +70,7 @@ object ActionUtils {
             String.format(
                 Locale.US,
                 "google.navigation:///?ll=%f,%f&q=%s",
-                lat, lng, label
+                lat, lng, Uri.encode(label)
             )
         )
         val intent = Intent(Intent.ACTION_VIEW, uri)

--- a/app/src/main/java/com/github/yuukis/businessmap/util/ActionUtils.kt
+++ b/app/src/main/java/com/github/yuukis/businessmap/util/ActionUtils.kt
@@ -111,7 +111,7 @@ object ActionUtils {
     }
 
     @JvmStatic
-    fun doRegisterContact(context: Context, lat: Double, lng: Double, address: String?) {
+    fun doRegisterContact(context: Context, address: String?) {
         val intent = Intent(Intent.ACTION_INSERT, Contacts.CONTENT_URI)
         intent.putExtra(Intents.Insert.POSTAL, address)
         intent.putExtra(Intents.Insert.POSTAL_TYPE, StructuredPostal.TYPE_WORK)

--- a/app/src/main/java/com/github/yuukis/businessmap/util/GeocoderUtils.kt
+++ b/app/src/main/java/com/github/yuukis/businessmap/util/GeocoderUtils.kt
@@ -44,6 +44,72 @@ object GeocoderUtils {
     private fun getFromLocationNameSync(context: Context, address: String): List<Address>? =
         Geocoder(context, Locale.getDefault()).getFromLocationName(address, 1)
 
+    @JvmStatic
+    suspend fun getFromLocation(context: Context, lat: Double, lng: Double): String {
+        return try {
+            val list = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                getFromLocationAsync(context, lat, lng)
+            } else {
+                getFromLocationSync(context, lat, lng)
+            }
+            list?.firstOrNull()?.getAddressLine(0).orEmpty()
+        } catch (e: IOException) {
+            getFromLocationToGoogleMaps(lat, lng)
+        }
+    }
+
+    @Suppress("DEPRECATION")
+    private fun getFromLocationSync(context: Context, lat: Double, lng: Double): List<Address>? =
+        Geocoder(context, Locale.getDefault()).getFromLocation(lat, lng, 1)
+
+    @RequiresApi(Build.VERSION_CODES.TIRAMISU)
+    private suspend fun getFromLocationAsync(context: Context, lat: Double, lng: Double): List<Address> =
+        suspendCancellableCoroutine { cont ->
+            Geocoder(context, Locale.getDefault()).getFromLocation(
+                lat,
+                lng,
+                1,
+                object : Geocoder.GeocodeListener {
+                    override fun onGeocode(addresses: MutableList<Address>) {
+                        if (cont.isActive) {
+                            cont.resume(addresses)
+                        }
+                    }
+
+                    override fun onError(errorMessage: String?) {
+                        if (cont.isActive) {
+                            cont.resumeWithException(IOException(errorMessage ?: "Reverse geocoding failed"))
+                        }
+                    }
+                }
+            )
+        }
+
+    @Throws(IOException::class)
+    private fun getFromLocationToGoogleMaps(lat: Double, lng: Double): String {
+        val urlFormat = "https://maps.google.com/maps/api/geocode/json?latlng=%f,%f&ka&sensor=false"
+        val url = String.format(Locale.US, urlFormat, lat, lng)
+        val stringBuilder = StringBuilder()
+
+        val connection = URL(url).openConnection() as HttpURLConnection
+        try {
+            val stream = connection.inputStream
+            var b: Int
+            while (stream.read().also { b = it } != -1) {
+                stringBuilder.append(b.toChar())
+            }
+        } finally {
+            connection.disconnect()
+        }
+
+        return try {
+            val jsonObject = JSONObject(stringBuilder.toString())
+            (jsonObject.get("results") as JSONArray).getJSONObject(0).getString("formatted_address")
+        } catch (e: JSONException) {
+            ""
+        }
+    }
+
     @RequiresApi(Build.VERSION_CODES.TIRAMISU)
     private suspend fun getFromLocationNameAsync(context: Context, address: String): List<Address> =
         suspendCancellableCoroutine { cont ->

--- a/app/src/main/java/com/github/yuukis/businessmap/util/GeocoderUtils.kt
+++ b/app/src/main/java/com/github/yuukis/businessmap/util/GeocoderUtils.kt
@@ -5,7 +5,9 @@ import android.location.Address
 import android.location.Geocoder
 import android.os.Build
 import androidx.annotation.RequiresApi
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withContext
 import org.json.JSONArray
 import org.json.JSONException
 import org.json.JSONObject
@@ -50,7 +52,7 @@ object GeocoderUtils {
             val list = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
                 getFromLocationAsync(context, lat, lng)
             } else {
-                getFromLocationSync(context, lat, lng)
+                withContext(Dispatchers.IO) { getFromLocationSync(context, lat, lng) }
             }
             list?.firstOrNull()?.getAddressLine(0).orEmpty()
         } catch (e: IOException) {

--- a/app/src/main/java/com/github/yuukis/businessmap/util/GeocoderUtils.kt
+++ b/app/src/main/java/com/github/yuukis/businessmap/util/GeocoderUtils.kt
@@ -57,6 +57,8 @@ object GeocoderUtils {
             list?.firstOrNull()?.getAddressLine(0).orEmpty()
         } catch (e: IOException) {
             ""
+        } catch (e: IllegalArgumentException) {
+            ""
         }
     }
 

--- a/app/src/main/java/com/github/yuukis/businessmap/util/GeocoderUtils.kt
+++ b/app/src/main/java/com/github/yuukis/businessmap/util/GeocoderUtils.kt
@@ -54,7 +54,7 @@ object GeocoderUtils {
             }
             list?.firstOrNull()?.getAddressLine(0).orEmpty()
         } catch (e: IOException) {
-            getFromLocationToGoogleMaps(lat, lng)
+            ""
         }
     }
 
@@ -84,31 +84,6 @@ object GeocoderUtils {
                 }
             )
         }
-
-    @Throws(IOException::class)
-    private fun getFromLocationToGoogleMaps(lat: Double, lng: Double): String {
-        val urlFormat = "https://maps.google.com/maps/api/geocode/json?latlng=%f,%f&ka&sensor=false"
-        val url = String.format(Locale.US, urlFormat, lat, lng)
-        val stringBuilder = StringBuilder()
-
-        val connection = URL(url).openConnection() as HttpURLConnection
-        try {
-            val stream = connection.inputStream
-            var b: Int
-            while (stream.read().also { b = it } != -1) {
-                stringBuilder.append(b.toChar())
-            }
-        } finally {
-            connection.disconnect()
-        }
-
-        return try {
-            val jsonObject = JSONObject(stringBuilder.toString())
-            (jsonObject.get("results") as JSONArray).getJSONObject(0).getString("formatted_address")
-        } catch (e: JSONException) {
-            ""
-        }
-    }
 
     @RequiresApi(Build.VERSION_CODES.TIRAMISU)
     private suspend fun getFromLocationNameAsync(context: Context, address: String): List<Address> =

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -28,6 +28,7 @@
     <string name="message_no_data" translatable="false">(未登録)</string>
     <string name="message_geocoding_address" translatable="false">住所を取得しています&#8230;</string>
     <string name="message_geocoding_failed" translatable="false">住所の取得に失敗しました</string>
+    <string name="label_selected_location" translatable="false">選択した地点</string>
     <string name="message_no_contacts" translatable="false">このグループに連絡先はありません</string>
     <string name="message_other_items" translatable="false">他 %d 件</string>
     <string name="format_progress_count" translatable="false">%1$d/%2$d</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -11,7 +11,7 @@
     <string name="action_directions" translatable="false">経路を調べる</string>
     <string name="action_drive_navigation" translatable="false">ナビを開始</string>
     <string name="action_street_view" translatable="false">ストリートビュー</string>
-    <string name="action_register_contact" translatable="false">連絡先を登録</string>
+    <string name="action_register_contact" translatable="false">連絡先に登録</string>
     <string name="action_select_group" translatable="false">グループを選択</string>
     <string name="action_select_contacts" translatable="false">連絡先を選択</string>
     <string name="label_app_name" translatable="false">アプリケーション名</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -27,6 +27,7 @@
     <string name="message_contacts_loaderror" translatable="false">連絡先を読み込めませんでした。もう一度お試しください。</string>
     <string name="message_no_data" translatable="false">(未登録)</string>
     <string name="message_geocoding_address" translatable="false">住所を取得しています&#8230;</string>
+    <string name="message_geocoding_failed" translatable="false">住所の取得に失敗しました</string>
     <string name="message_no_contacts" translatable="false">このグループに連絡先はありません</string>
     <string name="message_other_items" translatable="false">他 %d 件</string>
     <string name="format_progress_count" translatable="false">%1$d/%2$d</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -11,6 +11,7 @@
     <string name="action_directions" translatable="false">経路を調べる</string>
     <string name="action_drive_navigation" translatable="false">ナビを開始</string>
     <string name="action_street_view" translatable="false">ストリートビュー</string>
+    <string name="action_register_contact" translatable="false">連絡先を登録</string>
     <string name="action_select_group" translatable="false">グループを選択</string>
     <string name="action_select_contacts" translatable="false">連絡先を選択</string>
     <string name="label_app_name" translatable="false">アプリケーション名</string>
@@ -25,6 +26,7 @@
     <string name="title_contacts_loaderror" translatable="false">連絡先の取得に失敗しました</string>
     <string name="message_contacts_loaderror" translatable="false">連絡先を読み込めませんでした。もう一度お試しください。</string>
     <string name="message_no_data" translatable="false">(未登録)</string>
+    <string name="message_geocoding_address" translatable="false">住所を取得しています&#8230;</string>
     <string name="message_no_contacts" translatable="false">このグループに連絡先はありません</string>
     <string name="message_other_items" translatable="false">他 %d 件</string>
     <string name="format_progress_count" translatable="false">%1$d/%2$d</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -28,6 +28,7 @@
     <string name="message_no_data" translatable="false">No data.</string>
     <string name="message_geocoding_address" translatable="false">Getting address&#8230;</string>
     <string name="message_geocoding_failed" translatable="false">Failed to get address</string>
+    <string name="label_selected_location" translatable="false">Selected location</string>
     <string name="message_no_contacts" translatable="false">No contacts in this group.</string>
     <string name="message_other_items" translatable="false">%d other</string>
     <string name="format_progress_count" translatable="false">%1$d/%2$d</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -27,6 +27,7 @@
     <string name="message_contacts_loaderror" translatable="false">Could not read your contacts. Please try again.</string>
     <string name="message_no_data" translatable="false">No data.</string>
     <string name="message_geocoding_address" translatable="false">Getting address&#8230;</string>
+    <string name="message_geocoding_failed" translatable="false">Failed to get address</string>
     <string name="message_no_contacts" translatable="false">No contacts in this group.</string>
     <string name="message_other_items" translatable="false">%d other</string>
     <string name="format_progress_count" translatable="false">%1$d/%2$d</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -11,6 +11,7 @@
     <string name="action_directions" translatable="false">Directions</string>
     <string name="action_drive_navigation" translatable="false">Drive navigation</string>
     <string name="action_street_view" translatable="false">Street View</string>
+    <string name="action_register_contact" translatable="false">Register contact</string>
     <string name="action_select_group" translatable="false">Select group</string>
     <string name="action_select_contacts" translatable="false">Select contacts</string>
     <string name="label_app_name" translatable="false">Application Name</string>
@@ -25,6 +26,7 @@
     <string name="title_contacts_loaderror" translatable="false">Failed to load contacts</string>
     <string name="message_contacts_loaderror" translatable="false">Could not read your contacts. Please try again.</string>
     <string name="message_no_data" translatable="false">No data.</string>
+    <string name="message_geocoding_address" translatable="false">Getting address&#8230;</string>
     <string name="message_no_contacts" translatable="false">No contacts in this group.</string>
     <string name="message_other_items" translatable="false">%d other</string>
     <string name="format_progress_count" translatable="false">%1$d/%2$d</string>


### PR DESCRIPTION
## Summary
- 地図を長押しした地点にマーカーを表示し、逆ジオコーディングで取得した住所をふきだしに表示する
- ふきだしをタップすると、[連絡先を登録]/[経路を調べる]/[ナビを開始]/[ストリートビュー]を選べるアクションシート(`LocationActionFragment`)を表示する
- [連絡先を登録]選択時は住所付きの連絡先登録インテント(`ACTION_INSERT`)を発行する
- ふきだし以外をタップすると、長押しで追加したマーカーを削除する

Closes #29

## Test plan
- [x] `./gradlew :app:compileDebugKotlin`
- [x] `./gradlew :app:assembleDebug`
- [x] `./gradlew :app:assembleDebugAndroidTest`
- [x] `./gradlew :app:testDebugUnitTest`
- [x] `LocationActionFragmentTest` (実機/エミュレータ環境が無く未実行。CI等で確認をお願いします)

🤖 Generated with [Claude Code](https://claude.com/claude-code)