### PR TITLE
InfoWindowに連絡先画像を表示

### DIFF
--- a/app/src/androidTest/java/com/github/yuukis/businessmap/util/ContactPhotoLoaderTest.kt
+++ b/app/src/androidTest/java/com/github/yuukis/businessmap/util/ContactPhotoLoaderTest.kt
@@ -2,6 +2,7 @@ package com.github.yuukis.businessmap.util
 
 import android.graphics.Bitmap
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertSame
@@ -59,5 +60,20 @@ class ContactPhotoLoaderTest {
 
         assertEquals(0, result.getPixel(0, 0) ushr 24)
         assertEquals(0xff, result.getPixel(5, 5) ushr 24)
+    }
+
+    /**
+     * 非同期読み込みの完了後に、InfoWindowの再描画で利用できる画像がキャッシュされることを確認する。
+     */
+    @Test
+    fun cachesThumbnailLoadedAsynchronously() = runBlocking {
+        val expected = Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888)
+        val loader = ContactPhotoLoader { expected }
+
+        assertNull(loader.getCachedThumbnail(1L))
+        loader.loadThumbnailAsync(1L)
+
+        assertSame(loader.getCachedThumbnail(1L), loader.loadThumbnail(1L))
+        assertEquals(true, loader.isLoadCompleted(1L))
     }
 }

--- a/app/src/androidTest/java/com/github/yuukis/businessmap/util/ContactPhotoLoaderTest.kt
+++ b/app/src/androidTest/java/com/github/yuukis/businessmap/util/ContactPhotoLoaderTest.kt
@@ -1,0 +1,46 @@
+package com.github.yuukis.businessmap.util
+
+import android.graphics.Bitmap
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class ContactPhotoLoaderTest {
+
+    /**
+     * 一度読み込んだ連絡先画像をキャッシュし、同じ連絡先で画像を再取得しないことを確認する。
+     */
+    @Test
+    fun cachesLoadedThumbnail() {
+        val expected = Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888)
+        var readCount = 0
+        val loader = ContactPhotoLoader {
+            readCount++
+            expected
+        }
+
+        assertSame(expected, loader.loadThumbnail(1L))
+        assertSame(expected, loader.loadThumbnail(1L))
+        assertEquals(1, readCount)
+    }
+
+    /**
+     * 画像未登録の連絡先も結果を記憶し、InfoWindowの再描画で問い合わせを繰り返さないことを確認する。
+     */
+    @Test
+    fun cachesMissingThumbnail() {
+        var readCount = 0
+        val loader = ContactPhotoLoader {
+            readCount++
+            null
+        }
+
+        assertNull(loader.loadThumbnail(1L))
+        assertNull(loader.loadThumbnail(1L))
+        assertEquals(1, readCount)
+    }
+}

--- a/app/src/androidTest/java/com/github/yuukis/businessmap/util/ContactPhotoLoaderTest.kt
+++ b/app/src/androidTest/java/com/github/yuukis/businessmap/util/ContactPhotoLoaderTest.kt
@@ -2,6 +2,8 @@ package com.github.yuukis.businessmap.util
 
 import android.graphics.Bitmap
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
@@ -16,7 +18,7 @@ class ContactPhotoLoaderTest {
      * 一度読み込んだ連絡先画像をキャッシュし、同じ連絡先で画像を再取得しないことを確認する。
      */
     @Test
-    fun cachesLoadedThumbnail() {
+    fun cachesLoadedThumbnail() = runBlocking {
         val expected = Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888)
         var readCount = 0
         val loader = ContactPhotoLoader {
@@ -24,8 +26,8 @@ class ContactPhotoLoaderTest {
             expected
         }
 
-        val first = loader.loadThumbnail(1L)
-        val second = loader.loadThumbnail(1L)
+        val first = loader.loadThumbnailAsync(1L)
+        val second = loader.loadThumbnailAsync(1L)
 
         assertSame(first, second)
         assertEquals(1, readCount)
@@ -35,15 +37,15 @@ class ContactPhotoLoaderTest {
      * 画像未登録の連絡先も結果を記憶し、InfoWindowの再描画で問い合わせを繰り返さないことを確認する。
      */
     @Test
-    fun cachesMissingThumbnail() {
+    fun cachesMissingThumbnail() = runBlocking {
         var readCount = 0
         val loader = ContactPhotoLoader {
             readCount++
             null
         }
 
-        assertNull(loader.loadThumbnail(1L))
-        assertNull(loader.loadThumbnail(1L))
+        assertNull(loader.loadThumbnailAsync(1L))
+        assertNull(loader.loadThumbnailAsync(1L))
         assertEquals(1, readCount)
     }
 
@@ -73,7 +75,30 @@ class ContactPhotoLoaderTest {
         assertNull(loader.getCachedThumbnail(1L))
         loader.loadThumbnailAsync(1L)
 
-        assertSame(loader.getCachedThumbnail(1L), loader.loadThumbnail(1L))
+        assertSame(loader.getCachedThumbnail(1L), loader.loadThumbnailAsync(1L))
         assertEquals(true, loader.isLoadCompleted(1L))
+    }
+
+    /**
+     * 同じ連絡先の画像を同時に要求しても、Contacts Providerへの問い合わせが1回だけになることを確認する。
+     */
+    @Test
+    fun sharesConcurrentThumbnailLoad() = runBlocking {
+        val expected = Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888)
+        var readCount = 0
+        val loader = ContactPhotoLoader {
+            synchronized(this) {
+                readCount++
+            }
+            Thread.sleep(100)
+            expected
+        }
+
+        val results = List(2) {
+            async { loader.loadThumbnailAsync(1L) }
+        }.awaitAll()
+
+        assertSame(results[0], results[1])
+        assertEquals(1, readCount)
     }
 }

--- a/app/src/androidTest/java/com/github/yuukis/businessmap/util/ContactPhotoLoaderTest.kt
+++ b/app/src/androidTest/java/com/github/yuukis/businessmap/util/ContactPhotoLoaderTest.kt
@@ -23,8 +23,10 @@ class ContactPhotoLoaderTest {
             expected
         }
 
-        assertSame(expected, loader.loadThumbnail(1L))
-        assertSame(expected, loader.loadThumbnail(1L))
+        val first = loader.loadThumbnail(1L)
+        val second = loader.loadThumbnail(1L)
+
+        assertSame(first, second)
         assertEquals(1, readCount)
     }
 
@@ -42,5 +44,20 @@ class ContactPhotoLoaderTest {
         assertNull(loader.loadThumbnail(1L))
         assertNull(loader.loadThumbnail(1L))
         assertEquals(1, readCount)
+    }
+
+    /**
+     * 連絡先画像を円形に切り抜き、四隅が透明で中央に画像が残ることを確認する。
+     */
+    @Test
+    fun cropsThumbnailToCircle() {
+        val source = Bitmap.createBitmap(10, 10, Bitmap.Config.ARGB_8888).apply {
+            eraseColor(0xffff0000.toInt())
+        }
+
+        val result = ContactPhotoLoader.cropToCircle(source)
+
+        assertEquals(0, result.getPixel(0, 0) ushr 24)
+        assertEquals(0xff, result.getPixel(5, 5) ushr 24)
     }
 }

--- a/app/src/androidTest/java/com/github/yuukis/businessmap/util/ContactPhotoLoaderTest.kt
+++ b/app/src/androidTest/java/com/github/yuukis/businessmap/util/ContactPhotoLoaderTest.kt
@@ -86,8 +86,9 @@ class ContactPhotoLoaderTest {
     fun sharesConcurrentThumbnailLoad() = runBlocking {
         val expected = Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888)
         var readCount = 0
+        val readCountLock = Any()
         val loader = ContactPhotoLoader {
-            synchronized(this) {
+            synchronized(readCountLock) {
                 readCount++
             }
             Thread.sleep(100)

--- a/app/src/main/java/com/github/yuukis/businessmap/app/ContactsMapFragment.kt
+++ b/app/src/main/java/com/github/yuukis/businessmap/app/ContactsMapFragment.kt
@@ -230,8 +230,11 @@ class ContactsMapFragment :
         }
 
         removeLongPressMarker()
-        showContactInfoWindow(marker)
-        return true
+        loadContactPhotoAndRefreshInfoWindow(marker)
+        // Let Google Maps perform its normal marker selection and initial
+        // InfoWindow display. Calling showInfoWindow() synchronously from this
+        // callback can race that internal processing and lose the first show.
+        return false
     }
 
     private fun showContactInfoWindow(marker: Marker) {

--- a/app/src/main/java/com/github/yuukis/businessmap/app/ContactsMapFragment.kt
+++ b/app/src/main/java/com/github/yuukis/businessmap/app/ContactsMapFragment.kt
@@ -27,6 +27,7 @@ import android.text.TextUtils
 import android.util.SparseArray
 import android.view.View
 import android.widget.Button
+import android.widget.ImageView
 import android.widget.TextView
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.activityViewModels
@@ -34,6 +35,7 @@ import androidx.lifecycle.lifecycleScope
 import com.github.yuukis.businessmap.R
 import com.github.yuukis.businessmap.data.MapStatePreferences
 import com.github.yuukis.businessmap.model.ContactsItem
+import com.github.yuukis.businessmap.util.ContactPhotoLoader
 import com.github.yuukis.businessmap.util.GeocoderUtils
 import com.github.yuukis.businessmap.view.OnInfoWindowElemTouchListener
 import com.github.yuukis.businessmap.widget.MapWrapperLayout
@@ -70,12 +72,14 @@ class ContactsMapFragment :
     private val markerContactHashMap = SparseArray<ContactsItem>()
     private val latlngContactsHashMap = SparseArray<MutableList<ContactsItem>>()
     private lateinit var preferences: MapStatePreferences
+    private lateinit var contactPhotoLoader: ContactPhotoLoader
     private var longPressMarker: Marker? = null
     private var longPressAddress: String? = null
 
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
         preferences = MapStatePreferences(requireActivity())
+        contactPhotoLoader = ContactPhotoLoader(requireContext())
         getMapAsync(this)
     }
 
@@ -334,6 +338,7 @@ class ContactsMapFragment :
 
             val view = infoWindow ?: return null
             val tvTitle = view.findViewById<TextView>(R.id.title)
+            val contactPhoto = view.findViewById<ImageView>(R.id.contact_photo)
             val tvCompanyName = view.findViewById<TextView>(R.id.company_name)
             val tvSnippet = view.findViewById<TextView>(R.id.snippet)
             val tvNote = view.findViewById<TextView>(R.id.note)
@@ -342,6 +347,8 @@ class ContactsMapFragment :
             infoButtonListener?.setMarker(marker)
 
             if (marker == longPressMarker) {
+                contactPhoto.setImageDrawable(null)
+                contactPhoto.visibility = View.GONE
                 tvTitle.text = marker.title
                 tvCompanyName.visibility = View.GONE
                 tvSnippet.visibility = View.GONE
@@ -354,6 +361,15 @@ class ContactsMapFragment :
             }
 
             if (contacts != null) {
+                val photo = contactPhotoLoader.loadThumbnail(contacts.cid)
+                if (photo == null) {
+                    contactPhoto.setImageDrawable(null)
+                    contactPhoto.visibility = View.GONE
+                } else {
+                    contactPhoto.setImageBitmap(photo)
+                    contactPhoto.visibility = View.VISIBLE
+                }
+
                 val title = marker.title
                 tvTitle.text = title
 

--- a/app/src/main/java/com/github/yuukis/businessmap/app/ContactsMapFragment.kt
+++ b/app/src/main/java/com/github/yuukis/businessmap/app/ContactsMapFragment.kt
@@ -175,12 +175,12 @@ class ContactsMapFragment :
                     }
 
                     override fun onFinish() {
-                        marker.showInfoWindow()
+                        showContactInfoWindow(marker)
                     }
                 }
             )
         } else {
-            marker.showInfoWindow()
+            showContactInfoWindow(marker)
         }
         return true
     }
@@ -230,14 +230,27 @@ class ContactsMapFragment :
         }
 
         removeLongPressMarker()
-        markerContactHashMap[marker.hashCode()]?.let { contact ->
-            // Google Maps converts the InfoWindow view into an image while
-            // getInfoContents() is running. Load the contact photo before
-            // starting that conversion so the first tap can render it too.
-            contactPhotoLoader.loadThumbnail(contact.cid)
-        }
-        marker.showInfoWindow()
+        showContactInfoWindow(marker)
         return true
+    }
+
+    private fun showContactInfoWindow(marker: Marker) {
+        marker.showInfoWindow()
+        loadContactPhotoAndRefreshInfoWindow(marker)
+    }
+
+    private fun loadContactPhotoAndRefreshInfoWindow(marker: Marker) {
+        val contact = markerContactHashMap[marker.hashCode()] ?: return
+        if (contactPhotoLoader.isLoadCompleted(contact.cid)) {
+            return
+        }
+
+        viewLifecycleOwner.lifecycleScope.launch {
+            contactPhotoLoader.loadThumbnailAsync(contact.cid)
+            if (marker.isInfoWindowShown) {
+                marker.showInfoWindow()
+            }
+        }
     }
 
     private fun removeLongPressMarker() {
@@ -370,12 +383,15 @@ class ContactsMapFragment :
             }
 
             if (contacts != null) {
-                val photo = contactPhotoLoader.loadThumbnail(contacts.cid)
-                if (photo == null) {
+                val photo = contactPhotoLoader.getCachedThumbnail(contacts.cid)
+                if (photo != null) {
+                    contactPhoto.setImageBitmap(photo)
+                    contactPhoto.visibility = View.VISIBLE
+                } else if (contactPhotoLoader.isLoadCompleted(contacts.cid)) {
                     contactPhoto.setImageDrawable(null)
                     contactPhoto.visibility = View.GONE
                 } else {
-                    contactPhoto.setImageBitmap(photo)
+                    contactPhoto.setImageResource(R.drawable.contact_photo_placeholder)
                     contactPhoto.visibility = View.VISIBLE
                 }
 

--- a/app/src/main/java/com/github/yuukis/businessmap/app/ContactsMapFragment.kt
+++ b/app/src/main/java/com/github/yuukis/businessmap/app/ContactsMapFragment.kt
@@ -225,10 +225,19 @@ class ContactsMapFragment :
     }
 
     override fun onMarkerClick(marker: Marker): Boolean {
-        if (marker != longPressMarker) {
-            removeLongPressMarker()
+        if (marker == longPressMarker) {
+            return false
         }
-        return false
+
+        removeLongPressMarker()
+        markerContactHashMap[marker.hashCode()]?.let { contact ->
+            // Google Maps converts the InfoWindow view into an image while
+            // getInfoContents() is running. Load the contact photo before
+            // starting that conversion so the first tap can render it too.
+            contactPhotoLoader.loadThumbnail(contact.cid)
+        }
+        marker.showInfoWindow()
+        return true
     }
 
     private fun removeLongPressMarker() {

--- a/app/src/main/java/com/github/yuukis/businessmap/util/ContactPhotoLoader.kt
+++ b/app/src/main/java/com/github/yuukis/businessmap/util/ContactPhotoLoader.kt
@@ -28,6 +28,8 @@ import android.graphics.Paint
 import android.graphics.Shader
 import android.provider.ContactsContract.Contacts
 import android.util.LruCache
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import java.io.FileNotFoundException
 
 class ContactPhotoLoader internal constructor(
@@ -39,6 +41,18 @@ class ContactPhotoLoader internal constructor(
 
     constructor(context: Context) : this(createPhotoReader(context))
 
+    @Synchronized
+    fun getCachedThumbnail(contactId: Long): Bitmap? = bitmapCache[contactId]
+
+    @Synchronized
+    fun isLoadCompleted(contactId: Long): Boolean =
+        bitmapCache[contactId] != null || contactsWithoutPhoto.contains(contactId)
+
+    suspend fun loadThumbnailAsync(contactId: Long): Bitmap? = withContext(Dispatchers.IO) {
+        loadThumbnail(contactId)
+    }
+
+    @Synchronized
     fun loadThumbnail(contactId: Long): Bitmap? {
         bitmapCache[contactId]?.let { return it }
         if (contactsWithoutPhoto.contains(contactId)) {

--- a/app/src/main/java/com/github/yuukis/businessmap/util/ContactPhotoLoader.kt
+++ b/app/src/main/java/com/github/yuukis/businessmap/util/ContactPhotoLoader.kt
@@ -1,0 +1,61 @@
+/*
+ * ContactPhotoLoader.kt
+ *
+ * Copyright 2026 Yuuki Shimizu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.yuukis.businessmap.util
+
+import android.content.ContentUris
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.provider.ContactsContract.Contacts
+import android.util.LruCache
+import java.io.FileNotFoundException
+
+class ContactPhotoLoader(context: Context) {
+
+    private val contentResolver = context.applicationContext.contentResolver
+    private val bitmapCache = LruCache<Long, Bitmap>(MAX_CACHE_ENTRIES)
+    private val contactsWithoutPhoto = HashSet<Long>()
+
+    fun loadThumbnail(contactId: Long): Bitmap? {
+        bitmapCache[contactId]?.let { return it }
+        if (contactsWithoutPhoto.contains(contactId)) {
+            return null
+        }
+
+        val contactUri = ContentUris.withAppendedId(Contacts.CONTENT_URI, contactId)
+        val bitmap = try {
+            Contacts.openContactPhotoInputStream(contentResolver, contactUri, false)
+                ?.use(BitmapFactory::decodeStream)
+        } catch (_: FileNotFoundException) {
+            null
+        } catch (_: SecurityException) {
+            null
+        }
+
+        if (bitmap == null) {
+            contactsWithoutPhoto.add(contactId)
+        } else {
+            bitmapCache.put(contactId, bitmap)
+        }
+        return bitmap
+    }
+
+    companion object {
+        private const val MAX_CACHE_ENTRIES = 32
+    }
+}

--- a/app/src/main/java/com/github/yuukis/businessmap/util/ContactPhotoLoader.kt
+++ b/app/src/main/java/com/github/yuukis/businessmap/util/ContactPhotoLoader.kt
@@ -28,6 +28,7 @@ import android.graphics.Paint
 import android.graphics.Shader
 import android.provider.ContactsContract.Contacts
 import android.util.LruCache
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.io.FileNotFoundException
@@ -38,35 +39,68 @@ class ContactPhotoLoader internal constructor(
 
     private val bitmapCache = LruCache<Long, Bitmap>(MAX_CACHE_ENTRIES)
     private val contactsWithoutPhoto = HashSet<Long>()
+    private val loadingContacts = HashMap<Long, CompletableDeferred<Bitmap?>>()
+    private val cacheLock = Any()
 
     constructor(context: Context) : this(createPhotoReader(context))
 
-    @Synchronized
-    fun getCachedThumbnail(contactId: Long): Bitmap? = bitmapCache[contactId]
-
-    @Synchronized
-    fun isLoadCompleted(contactId: Long): Boolean =
-        bitmapCache[contactId] != null || contactsWithoutPhoto.contains(contactId)
-
-    suspend fun loadThumbnailAsync(contactId: Long): Bitmap? = withContext(Dispatchers.IO) {
-        loadThumbnail(contactId)
+    fun getCachedThumbnail(contactId: Long): Bitmap? = synchronized(cacheLock) {
+        bitmapCache[contactId]
     }
 
-    @Synchronized
-    fun loadThumbnail(contactId: Long): Bitmap? {
-        bitmapCache[contactId]?.let { return it }
-        if (contactsWithoutPhoto.contains(contactId)) {
-            return null
+    fun isLoadCompleted(contactId: Long): Boolean = synchronized(cacheLock) {
+        bitmapCache[contactId] != null || contactsWithoutPhoto.contains(contactId)
+    }
+
+    suspend fun loadThumbnailAsync(contactId: Long): Bitmap? = withContext(Dispatchers.IO) {
+        val loadState = synchronized(cacheLock) {
+            bitmapCache[contactId]?.let { return@synchronized LoadState.Completed(it) }
+            if (contactsWithoutPhoto.contains(contactId)) {
+                return@synchronized LoadState.Completed(null)
+            }
+            loadingContacts[contactId]?.let { return@synchronized LoadState.InProgress(it, false) }
+
+            val deferred = CompletableDeferred<Bitmap?>()
+            loadingContacts[contactId] = deferred
+            LoadState.InProgress(deferred, true)
         }
 
-        val bitmap = photoReader(contactId)?.let(::cropToCircle)
+        when (loadState) {
+            is LoadState.Completed -> loadState.bitmap
+            is LoadState.InProgress -> {
+                if (!loadState.isOwner) {
+                    return@withContext loadState.result.await()
+                }
 
-        if (bitmap == null) {
-            contactsWithoutPhoto.add(contactId)
-        } else {
-            bitmapCache.put(contactId, bitmap)
+                try {
+                    val bitmap = photoReader(contactId)?.let(::cropToCircle)
+                    synchronized(cacheLock) {
+                        if (bitmap == null) {
+                            contactsWithoutPhoto.add(contactId)
+                        } else {
+                            bitmapCache.put(contactId, bitmap)
+                        }
+                        loadingContacts.remove(contactId)
+                    }
+                    loadState.result.complete(bitmap)
+                    bitmap
+                } catch (throwable: Throwable) {
+                    synchronized(cacheLock) {
+                        loadingContacts.remove(contactId)
+                    }
+                    loadState.result.completeExceptionally(throwable)
+                    throw throwable
+                }
+            }
         }
-        return bitmap
+    }
+
+    private sealed interface LoadState {
+        data class Completed(val bitmap: Bitmap?) : LoadState
+        data class InProgress(
+            val result: CompletableDeferred<Bitmap?>,
+            val isOwner: Boolean
+        ) : LoadState
     }
 
     companion object {

--- a/app/src/main/java/com/github/yuukis/businessmap/util/ContactPhotoLoader.kt
+++ b/app/src/main/java/com/github/yuukis/businessmap/util/ContactPhotoLoader.kt
@@ -25,11 +25,14 @@ import android.provider.ContactsContract.Contacts
 import android.util.LruCache
 import java.io.FileNotFoundException
 
-class ContactPhotoLoader(context: Context) {
+class ContactPhotoLoader internal constructor(
+    private val photoReader: (Long) -> Bitmap?
+) {
 
-    private val contentResolver = context.applicationContext.contentResolver
     private val bitmapCache = LruCache<Long, Bitmap>(MAX_CACHE_ENTRIES)
     private val contactsWithoutPhoto = HashSet<Long>()
+
+    constructor(context: Context) : this(createPhotoReader(context))
 
     fun loadThumbnail(contactId: Long): Bitmap? {
         bitmapCache[contactId]?.let { return it }
@@ -37,15 +40,7 @@ class ContactPhotoLoader(context: Context) {
             return null
         }
 
-        val contactUri = ContentUris.withAppendedId(Contacts.CONTENT_URI, contactId)
-        val bitmap = try {
-            Contacts.openContactPhotoInputStream(contentResolver, contactUri, false)
-                ?.use(BitmapFactory::decodeStream)
-        } catch (_: FileNotFoundException) {
-            null
-        } catch (_: SecurityException) {
-            null
-        }
+        val bitmap = photoReader(contactId)
 
         if (bitmap == null) {
             contactsWithoutPhoto.add(contactId)
@@ -57,5 +52,20 @@ class ContactPhotoLoader(context: Context) {
 
     companion object {
         private const val MAX_CACHE_ENTRIES = 32
+
+        private fun createPhotoReader(context: Context): (Long) -> Bitmap? {
+            val contentResolver = context.applicationContext.contentResolver
+            return { contactId ->
+                val contactUri = ContentUris.withAppendedId(Contacts.CONTENT_URI, contactId)
+                try {
+                    Contacts.openContactPhotoInputStream(contentResolver, contactUri, false)
+                        ?.use(BitmapFactory::decodeStream)
+                } catch (_: FileNotFoundException) {
+                    null
+                } catch (_: SecurityException) {
+                    null
+                }
+            }
+        }
     }
 }

--- a/app/src/main/java/com/github/yuukis/businessmap/util/ContactPhotoLoader.kt
+++ b/app/src/main/java/com/github/yuukis/businessmap/util/ContactPhotoLoader.kt
@@ -21,6 +21,11 @@ import android.content.ContentUris
 import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
+import android.graphics.BitmapShader
+import android.graphics.Canvas
+import android.graphics.Matrix
+import android.graphics.Paint
+import android.graphics.Shader
 import android.provider.ContactsContract.Contacts
 import android.util.LruCache
 import java.io.FileNotFoundException
@@ -40,7 +45,7 @@ class ContactPhotoLoader internal constructor(
             return null
         }
 
-        val bitmap = photoReader(contactId)
+        val bitmap = photoReader(contactId)?.let(::cropToCircle)
 
         if (bitmap == null) {
             contactsWithoutPhoto.add(contactId)
@@ -52,6 +57,27 @@ class ContactPhotoLoader internal constructor(
 
     companion object {
         private const val MAX_CACHE_ENTRIES = 32
+
+        internal fun cropToCircle(source: Bitmap): Bitmap {
+            val size = minOf(source.width, source.height)
+            val result = Bitmap.createBitmap(size, size, Bitmap.Config.ARGB_8888)
+            val shader = BitmapShader(source, Shader.TileMode.CLAMP, Shader.TileMode.CLAMP)
+            val matrix = Matrix().apply {
+                setTranslate(
+                    (size - source.width) / 2f,
+                    (size - source.height) / 2f
+                )
+            }
+            shader.setLocalMatrix(matrix)
+
+            Canvas(result).drawCircle(
+                size / 2f,
+                size / 2f,
+                size / 2f,
+                Paint(Paint.ANTI_ALIAS_FLAG).apply { this.shader = shader }
+            )
+            return result
+        }
 
         private fun createPhotoReader(context: Context): (Long) -> Bitmap? {
             val contentResolver = context.applicationContext.contentResolver

--- a/app/src/main/res/drawable/contact_photo_background.xml
+++ b/app/src/main/res/drawable/contact_photo_background.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="oval">
+    <solid android:color="@android:color/transparent" />
+</shape>

--- a/app/src/main/res/drawable/contact_photo_background.xml
+++ b/app/src/main/res/drawable/contact_photo_background.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<shape xmlns:android="http://schemas.android.com/apk/res/android"
-    android:shape="oval">
-    <solid android:color="@android:color/transparent" />
-</shape>

--- a/app/src/main/res/drawable/contact_photo_placeholder.xml
+++ b/app/src/main/res/drawable/contact_photo_placeholder.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="40dp"
+    android:height="40dp"
+    android:viewportWidth="40"
+    android:viewportHeight="40">
+    <path
+        android:fillColor="#FFE0E0E0"
+        android:pathData="M20,0A20,20 0,1 0,20 40A20,20 0,1 0,20 0" />
+    <path
+        android:fillColor="#FF9E9E9E"
+        android:pathData="M20,9A7,7 0,1 0,20 23A7,7 0,1 0,20 9M8,36C8,28.7 13.4,25 20,25C26.6,25 32,28.7 32,36Z" />
+</vector>

--- a/app/src/main/res/layout/marker_info_contents.xml
+++ b/app/src/main/res/layout/marker_info_contents.xml
@@ -4,28 +4,52 @@
     android:layout_height="wrap_content"
     android:orientation="vertical" >
 
-    <TextView
-        android:id="@+id/title"
+    <LinearLayout
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center_horizontal"
-        android:ellipsize="end"
-        android:singleLine="true"
-        android:textColor="#ff000000"
-        android:textSize="16dp"
-        android:textStyle="bold" />
+        android:gravity="center_vertical"
+        android:orientation="horizontal">
 
-    <TextView
-        android:id="@+id/company_name"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center_horizontal"
-        android:layout_marginBottom="2dp"
-        android:background="@drawable/rounded_corner"
-        android:ellipsize="end"
-        android:singleLine="true"
-        android:textColor="#ff444444"
-        android:textSize="10dp" />
+        <ImageView
+            android:id="@+id/contact_photo"
+            android:layout_width="40dp"
+            android:layout_height="40dp"
+            android:layout_marginEnd="8dp"
+            android:background="@drawable/contact_photo_background"
+            android:clipToOutline="true"
+            android:contentDescription="@null"
+            android:scaleType="centerCrop"
+            android:visibility="gone" />
+
+        <LinearLayout
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:gravity="center_horizontal"
+            android:orientation="vertical">
+
+            <TextView
+                android:id="@+id/title"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:ellipsize="end"
+                android:singleLine="true"
+                android:textColor="#ff000000"
+                android:textSize="16dp"
+                android:textStyle="bold" />
+
+            <TextView
+                android:id="@+id/company_name"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="2dp"
+                android:background="@drawable/rounded_corner"
+                android:ellipsize="end"
+                android:singleLine="true"
+                android:textColor="#ff444444"
+                android:textSize="10dp" />
+        </LinearLayout>
+    </LinearLayout>
 
     <LinearLayout
         android:layout_width="wrap_content"

--- a/app/src/main/res/layout/marker_info_contents.xml
+++ b/app/src/main/res/layout/marker_info_contents.xml
@@ -1,55 +1,43 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:orientation="vertical" >
 
-    <LinearLayout
+    <com.google.android.material.imageview.ShapeableImageView
+        android:id="@+id/contact_photo"
+        android:layout_width="40dp"
+        android:layout_height="40dp"
+        android:layout_gravity="center_horizontal"
+        android:layout_marginBottom="4dp"
+        android:contentDescription="@null"
+        android:scaleType="centerCrop"
+        android:visibility="gone"
+        app:shapeAppearanceOverlay="@style/ShapeAppearance.BusinessMap.Circle" />
+
+    <TextView
+        android:id="@+id/title"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center_horizontal"
-        android:gravity="center_vertical"
-        android:orientation="horizontal">
+        android:ellipsize="end"
+        android:singleLine="true"
+        android:textColor="#ff000000"
+        android:textSize="16dp"
+        android:textStyle="bold" />
 
-        <ImageView
-            android:id="@+id/contact_photo"
-            android:layout_width="40dp"
-            android:layout_height="40dp"
-            android:layout_marginEnd="8dp"
-            android:background="@drawable/contact_photo_background"
-            android:clipToOutline="true"
-            android:contentDescription="@null"
-            android:scaleType="centerCrop"
-            android:visibility="gone" />
-
-        <LinearLayout
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:gravity="center_horizontal"
-            android:orientation="vertical">
-
-            <TextView
-                android:id="@+id/title"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:ellipsize="end"
-                android:singleLine="true"
-                android:textColor="#ff000000"
-                android:textSize="16dp"
-                android:textStyle="bold" />
-
-            <TextView
-                android:id="@+id/company_name"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginBottom="2dp"
-                android:background="@drawable/rounded_corner"
-                android:ellipsize="end"
-                android:singleLine="true"
-                android:textColor="#ff444444"
-                android:textSize="10dp" />
-        </LinearLayout>
-    </LinearLayout>
+    <TextView
+        android:id="@+id/company_name"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_horizontal"
+        android:layout_marginBottom="2dp"
+        android:background="@drawable/rounded_corner"
+        android:ellipsize="end"
+        android:singleLine="true"
+        android:textColor="#ff444444"
+        android:textSize="10dp" />
 
     <LinearLayout
         android:layout_width="wrap_content"

--- a/app/src/main/res/layout/marker_info_contents.xml
+++ b/app/src/main/res/layout/marker_info_contents.xml
@@ -9,6 +9,7 @@
         android:layout_width="40dp"
         android:layout_height="40dp"
         android:layout_gravity="center_horizontal"
+        android:layout_marginTop="4dp"
         android:layout_marginBottom="4dp"
         android:contentDescription="@null"
         android:scaleType="centerCrop"

--- a/app/src/main/res/layout/marker_info_contents.xml
+++ b/app/src/main/res/layout/marker_info_contents.xml
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:orientation="vertical" >
 
-    <com.google.android.material.imageview.ShapeableImageView
+    <ImageView
         android:id="@+id/contact_photo"
         android:layout_width="40dp"
         android:layout_height="40dp"
@@ -13,8 +12,7 @@
         android:layout_marginBottom="4dp"
         android:contentDescription="@null"
         android:scaleType="centerCrop"
-        android:visibility="gone"
-        app:shapeAppearanceOverlay="@style/ShapeAppearance.BusinessMap.Circle" />
+        android:visibility="gone" />
 
     <TextView
         android:id="@+id/title"

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,11 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <style name="ShapeAppearance.BusinessMap.Circle" parent="">
-        <item name="cornerFamily">rounded</item>
-        <item name="cornerSize">50%</item>
-    </style>
-
     <!--
         Base application theme, dependent on API level. This theme is replaced
         by AppBaseTheme from res/values-vXX/styles.xml on newer devices.

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,6 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
+    <style name="ShapeAppearance.BusinessMap.Circle" parent="">
+        <item name="cornerFamily">rounded</item>
+        <item name="cornerSize">50%</item>
+    </style>
+
     <!--
         Base application theme, dependent on API level. This theme is replaced
         by AppBaseTheme from res/values-vXX/styles.xml on newer devices.


### PR DESCRIPTION
## 概要

地図のマーカーを選択した際に表示されるInfoWindowへ、連絡先に登録された画像を表示します。

## 変更内容

- 連絡先画像をInfoWindowのタイトル上部へ丸型アイコンとして表示
- 画像をバックグラウンドで取得し、取得完了後に表示中のInfoWindowを再描画
- 画像取得中のプレースホルダーを追加
- 取得済み画像と画像未登録の結果をメモリキャッシュ
- 画像なしの場合は従来のInfoWindow表示を維持
- 画像読み込みと円形加工のinstrumentationテストを追加

## 検証

- `sh ./gradlew :app:testDebugUnitTest :app:assembleDebugAndroidTest`
- Pixel 7a (Android 17) で `ContactPhotoLoaderTest` 4件成功
- 実機で初回タップ時の画像付きInfoWindow表示を確認

Closes #37