### PR TITLE
ジオコーディングの非公式Google Maps APIフォールバックを削除

### DIFF
--- a/app/src/main/java/com/github/yuukis/businessmap/app/MainActivityViewModel.kt
+++ b/app/src/main/java/com/github/yuukis/businessmap/app/MainActivityViewModel.kt
@@ -52,7 +52,6 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
-import org.json.JSONException
 import java.io.FileNotFoundException
 import java.io.IOException
 
@@ -449,14 +448,6 @@ class MainActivityViewModel(application: Application) : AndroidViewModel(applica
                 MainActivityEvent.ShowError(
                     context.getString(R.string.title_geocoding_ioerror),
                     context.getString(R.string.message_geocoding_ioerror)
-                )
-            )
-            return
-        } catch (e: JSONException) {
-            _events.trySend(
-                MainActivityEvent.ShowError(
-                    context.getString(R.string.title_geocoding_jsonerror),
-                    context.getString(R.string.message_geocoding_jsonerror)
                 )
             )
             return

--- a/app/src/main/java/com/github/yuukis/businessmap/util/GeocoderUtils.kt
+++ b/app/src/main/java/com/github/yuukis/businessmap/util/GeocoderUtils.kt
@@ -21,7 +21,7 @@ object GeocoderUtils {
         val list = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             getFromLocationNameAsync(context, address)
         } else {
-            getFromLocationNameSync(context, address)
+            withContext(Dispatchers.IO) { getFromLocationNameSync(context, address) }
         }
         var lat = Double.NaN
         var lng = Double.NaN

--- a/app/src/main/java/com/github/yuukis/businessmap/util/GeocoderUtils.kt
+++ b/app/src/main/java/com/github/yuukis/businessmap/util/GeocoderUtils.kt
@@ -8,13 +8,7 @@ import androidx.annotation.RequiresApi
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withContext
-import org.json.JSONArray
-import org.json.JSONException
-import org.json.JSONObject
 import java.io.IOException
-import java.net.HttpURLConnection
-import java.net.URL
-import java.net.URLEncoder
 import java.util.Locale
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
@@ -22,24 +16,20 @@ import kotlin.coroutines.resumeWithException
 object GeocoderUtils {
 
     @JvmStatic
-    @Throws(IOException::class, JSONException::class)
+    @Throws(IOException::class)
     suspend fun getFromLocationName(context: Context, address: String): Array<Double?> {
-        return try {
-            val list = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                getFromLocationNameAsync(context, address)
-            } else {
-                getFromLocationNameSync(context, address)
-            }
-            var lat = Double.NaN
-            var lng = Double.NaN
-            if (!list.isNullOrEmpty()) {
-                lat = list[0].latitude
-                lng = list[0].longitude
-            }
-            arrayOf(lat, lng)
-        } catch (e: IOException) {
-            getFromLocationNameToGoogleMaps(address)
+        val list = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            getFromLocationNameAsync(context, address)
+        } else {
+            getFromLocationNameSync(context, address)
         }
+        var lat = Double.NaN
+        var lng = Double.NaN
+        if (!list.isNullOrEmpty()) {
+            lat = list[0].latitude
+            lng = list[0].longitude
+        }
+        return arrayOf(lat, lng)
     }
 
     @Suppress("DEPRECATION")
@@ -110,43 +100,4 @@ object GeocoderUtils {
                 }
             )
         }
-
-    @Throws(IOException::class, JSONException::class)
-    private fun getFromLocationNameToGoogleMaps(address: String): Array<Double?> {
-        val urlFormat = "https://maps.google.com/maps/api/geocode/json?address=%s&ka&sensor=false"
-        val encodedAddress = URLEncoder.encode(address, "UTF-8")
-        val url = String.format(Locale.getDefault(), urlFormat, encodedAddress)
-        val stringBuilder = StringBuilder()
-
-        val connection = URL(url).openConnection() as HttpURLConnection
-        try {
-            val stream = connection.inputStream
-            var b: Int
-            while (stream.read().also { b = it } != -1) {
-                stringBuilder.append(b.toChar())
-            }
-        } finally {
-            connection.disconnect()
-        }
-
-        val jsonObject = JSONObject(stringBuilder.toString())
-        var lat = Double.NaN
-        var lng = Double.NaN
-        try {
-            lat = (jsonObject.get("results") as JSONArray)
-                .getJSONObject(0)
-                .getJSONObject("geometry")
-                .getJSONObject("location")
-                .getDouble("lat")
-            lng = (jsonObject.get("results") as JSONArray)
-                .getJSONObject(0)
-                .getJSONObject("geometry")
-                .getJSONObject("location")
-                .getDouble("lng")
-        } catch (e: JSONException) {
-            e.printStackTrace()
-        }
-
-        return arrayOf(lat, lng)
-    }
 }

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -19,10 +19,8 @@
     <string name="label_version" translatable="false">バージョン</string>
     <string name="title_geocoding" translatable="false">しばらくお待ちください</string>
     <string name="title_geocoding_ioerror" translatable="false">ネットワークに接続できません</string>
-    <string name="title_geocoding_jsonerror" translatable="false">サーバ エラー</string>
     <string name="message_geocoding" translatable="false">新しく登録された住所を座標に変換しています&#8230;</string>
     <string name="message_geocoding_ioerror" translatable="false">ネットワークへの接続に失敗したため、住所から座標へ変換できませんでした。</string>
-    <string name="message_geocoding_jsonerror" translatable="false">サーバ エラーが発生したため、住所から座標へ変換できませんでした。しばらく経ってから再度実行してください。</string>
     <string name="title_contacts_loaderror" translatable="false">連絡先の取得に失敗しました</string>
     <string name="message_contacts_loaderror" translatable="false">連絡先を読み込めませんでした。もう一度お試しください。</string>
     <string name="message_no_data" translatable="false">(未登録)</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -19,10 +19,8 @@
     <string name="label_version" translatable="false">Version</string>
     <string name="title_geocoding" translatable="false">Please wait a moment</string>
     <string name="title_geocoding_ioerror" translatable="false">Network Unavailable</string>
-    <string name="title_geocoding_jsonerror" translatable="false">Server error</string>
     <string name="message_geocoding" translatable="false">finding coordinates from the address registered newly &#8230;</string>
     <string name="message_geocoding_ioerror" translatable="false">Failed to find coordinates from the address because the network is unavailable.</string>
-    <string name="message_geocoding_jsonerror" translatable="false">Failed to find coordinates from the address because the server returned an error.</string>
     <string name="title_contacts_loaderror" translatable="false">Failed to load contacts</string>
     <string name="message_contacts_loaderror" translatable="false">Could not read your contacts. Please try again.</string>
     <string name="message_no_data" translatable="false">No data.</string>


### PR DESCRIPTION
## Summary
- 端末標準の`Geocoder`が失敗した際に、APIキー無しの非公式エンドポイント(`maps.google.com/maps/api/geocode/json`)へ連絡先住所を送信していたフォールバック処理を削除
- Google Maps Platformの利用規約上のリスク回避と、Play Consoleのデータセーフティフォーム申告の簡素化（連絡先住所のサードパーティ送信が無くなる）が目的
- 関連: #89 (ストア公開対応チェックリスト)

## Test plan
- [x] `./gradlew :app:compileDebugKotlin` でビルド確認
- [ ] 実機/エミュレータで連絡先の住所ジオコーディングが正常に動作することを確認