### PR TITLE
進捗ダイアログのダークモード表示とキャンセル動作を修正

### DIFF
--- a/app/src/androidTest/java/com/github/yuukis/businessmap/app/ProgressDialogFragmentTest.kt
+++ b/app/src/androidTest/java/com/github/yuukis/businessmap/app/ProgressDialogFragmentTest.kt
@@ -3,9 +3,13 @@ package com.github.yuukis.businessmap.app
 import android.os.Bundle
 import androidx.compose.ui.test.junit4.createEmptyComposeRule
 import androidx.compose.ui.test.onNodeWithText
+import androidx.lifecycle.Lifecycle
 import androidx.test.core.app.ActivityScenario
+import androidx.test.espresso.Espresso.pressBackUnconditionally
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.fragment.app.FragmentActivity
 import org.junit.Assert.assertEquals
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -16,7 +20,12 @@ class ProgressDialogFragmentTest {
     @get:Rule
     val composeTestRule = createEmptyComposeRule()
 
-    private fun showDialog(activity: FakeProgressDialogListenerActivity, max: Int): ProgressDialogFragment {
+    @Before
+    fun grantRuntimePermissions() {
+        TestPermissions.grantContactsAndLocation()
+    }
+
+    private fun showDialog(activity: FragmentActivity, max: Int): ProgressDialogFragment {
         val fragment = ProgressDialogFragment.newInstance()
         fragment.arguments = Bundle().apply {
             putString(ProgressDialogFragment.TITLE, "Please wait")
@@ -67,6 +76,23 @@ class ProgressDialogFragmentTest {
             scenario.onActivity { activity ->
                 assertEquals(1, activity.cancelledCallbackCount)
             }
+        }
+    }
+
+    @Test
+    fun pressingBackOnProgressDialogFinishesMainActivity() {
+        ActivityScenario.launch(MainActivity::class.java).use { scenario ->
+            scenario.onActivity { activity ->
+                showDialog(activity, max = 10)
+            }
+            composeTestRule.waitForIdle()
+
+            pressBackUnconditionally()
+
+            composeTestRule.waitUntil(timeoutMillis = 5_000) {
+                scenario.state == Lifecycle.State.DESTROYED
+            }
+            assertEquals(Lifecycle.State.DESTROYED, scenario.state)
         }
     }
 }

--- a/app/src/main/java/com/github/yuukis/businessmap/app/MainActivity.kt
+++ b/app/src/main/java/com/github/yuukis/businessmap/app/MainActivity.kt
@@ -183,6 +183,7 @@ open class MainActivity : AppCompatActivity(),
 
     override fun onProgressCancelled() {
         viewModel.cancelContactsTask()
+        finish()
     }
 
     private fun mapFragment(): ContactsMapFragment? =

--- a/app/src/main/java/com/github/yuukis/businessmap/app/ProgressDialogFragment.kt
+++ b/app/src/main/java/com/github/yuukis/businessmap/app/ProgressDialogFragment.kt
@@ -114,6 +114,7 @@ private fun ProgressContent(message: String, progress: Int, max: Int) {
     ) {
         Text(
             text = message,
+            color = MaterialTheme.colorScheme.onSurface,
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(bottom = 16.dp)


### PR DESCRIPTION
## 概要

`ProgressDialogFragment` のダークモード表示と、戻る操作でキャンセルした際のアプリ動作を修正します。

## 変更内容

- 進捗メッセージの文字色に `MaterialTheme.colorScheme.onSurface` を明示
- ダークモードでもダイアログ背景に適した文字色で表示
- 進捗ダイアログのキャンセル時に連絡先処理を中止して `MainActivity` を終了
- 実際の戻る操作からActivityが `DESTROYED` になるinstrumentation testを追加

## 確認結果

- `./gradlew :app:testDebugUnitTest :app:compileDebugAndroidTestKotlin`
- Pixel 7aで `ProgressDialogFragmentTest` を実行
  - 3/3テスト成功
