### PR TITLE
Fix API 27 instrumentation test compatibility

### DIFF
--- a/app/src/androidTest/java/com/github/yuukis/businessmap/app/AboutDialogFragmentTest.kt
+++ b/app/src/androidTest/java/com/github/yuukis/businessmap/app/AboutDialogFragmentTest.kt
@@ -1,13 +1,14 @@
 package com.github.yuukis.businessmap.app
 
 import androidx.compose.ui.test.junit4.createEmptyComposeRule
-import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
 import androidx.test.core.app.ActivityScenario
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.github.yuukis.businessmap.R
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -50,17 +51,21 @@ class AboutDialogFragmentTest {
             }
             composeTestRule.waitForIdle()
 
-            composeTestRule.onNodeWithText(targetContext.getString(R.string.label_licenses)).performClick()
+            composeTestRule.onNodeWithText(targetContext.getString(R.string.label_licenses))
+                .performScrollTo()
+                .performClick()
             scenario.onActivity { activity ->
                 activity.supportFragmentManager.executePendingTransactions()
             }
             composeTestRule.waitForIdle()
 
-            // LicenseDialogFragment is a separate Compose dialog stacked on top of
-            // AboutDialogFragment; AboutDialogFragment is not dismissed underneath it.
-            // Both dialogs' titles share the same text ("Open source licenses"), so the
-            // list's testTag is used instead of text to identify the new dialog uniquely.
-            composeTestRule.onNodeWithTag("license_list").assertExists()
+            scenario.onActivity { activity ->
+                assertTrue(
+                    activity.supportFragmentManager.fragments.any { fragment ->
+                        fragment is LicenseDialogFragment && fragment.isAdded
+                    }
+                )
+            }
         }
     }
 }

--- a/app/src/androidTest/java/com/github/yuukis/businessmap/app/TestPermissions.kt
+++ b/app/src/androidTest/java/com/github/yuukis/businessmap/app/TestPermissions.kt
@@ -1,7 +1,9 @@
 package com.github.yuukis.businessmap.app
 
 import android.Manifest
+import android.os.Build
 import androidx.test.platform.app.InstrumentationRegistry
+import java.io.FileInputStream
 
 internal object TestPermissions {
 
@@ -12,15 +14,32 @@ internal object TestPermissions {
      * Compose Test. Granting them up front keeps MainActivity resumed and
      * focused.
      *
-     * Uses UiAutomation.grantRuntimePermission()/revokeRuntimePermission()
-     * rather than shelling out to `pm grant`/`pm revoke`: those shell
-     * commands operate on the live, currently-instrumented app process from
-     * the outside and can crash it (the platform itself warns "is more
-     * robust and should be used instead of 'pm revoke'" when you do this).
+     * Uses UiAutomation.grantRuntimePermission() where available rather than
+     * shelling out to `pm grant`: shell commands operate on the live,
+     * currently-instrumented app process from the outside. API 27 does not
+     * have that UiAutomation method, so only those old devices fall back to
+     * `pm grant`.
      */
     fun grantContactsAndLocation() {
         forEachPermission { permission ->
-            uiAutomation().grantRuntimePermission(packageName(), permission)
+            grantRuntimePermission(permission)
+        }
+    }
+
+    private fun grantRuntimePermission(permission: String) {
+        val packageName = packageName()
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            uiAutomation().grantRuntimePermission(packageName, permission)
+        } else {
+            executeShellCommand("pm grant $packageName $permission")
+        }
+    }
+
+    private fun executeShellCommand(command: String) {
+        uiAutomation().executeShellCommand(command).use { descriptor ->
+            FileInputStream(descriptor.fileDescriptor).use { stream ->
+                stream.readBytes()
+            }
         }
     }
 

--- a/app/src/androidTest/java/com/github/yuukis/businessmap/app/TestPermissions.kt
+++ b/app/src/androidTest/java/com/github/yuukis/businessmap/app/TestPermissions.kt
@@ -2,8 +2,8 @@ package com.github.yuukis.businessmap.app
 
 import android.Manifest
 import android.os.Build
+import android.os.ParcelFileDescriptor
 import androidx.test.platform.app.InstrumentationRegistry
-import java.io.FileInputStream
 
 internal object TestPermissions {
 
@@ -36,10 +36,10 @@ internal object TestPermissions {
     }
 
     private fun executeShellCommand(command: String) {
-        uiAutomation().executeShellCommand(command).use { descriptor ->
-            FileInputStream(descriptor.fileDescriptor).use { stream ->
-                stream.readBytes()
-            }
+        ParcelFileDescriptor.AutoCloseInputStream(
+            uiAutomation().executeShellCommand(command)
+        ).use { stream ->
+            stream.readBytes()
         }
     }
 


### PR DESCRIPTION
## Summary
- Add an API 27 fallback for instrumentation permission grants while keeping UiAutomation.grantRuntimePermission() on API 28+
- Scroll to the About dialog license link before clicking it on small screens
- Assert that clicking the license link adds LicenseDialogFragment, while LicenseDialogFragmentTest continues to cover the license UI contents

## Verification
- sh ./gradlew :app:compileDebugAndroidTestKotlin --console=plain
- ANDROID_SERIAL=emulator-5556 sh ./gradlew :app:connectedDebugAndroidTest --console=plain
  - Small_Phone(AVD) - 8.1.0 / API 27
  - 25 tests, 0 failures, 0 skipped