### PR TITLE
Persist map camera position on pause

### DIFF
--- a/app/src/main/java/com/github/yuukis/businessmap/app/ContactsMapFragment.kt
+++ b/app/src/main/java/com/github/yuukis/businessmap/app/ContactsMapFragment.kt
@@ -88,6 +88,11 @@ class ContactsMapFragment :
         getMapAsync(this)
     }
 
+    override fun onPause() {
+        saveCameraPosition()
+        super.onPause()
+    }
+
     override fun onMapReady(googleMap: GoogleMap) {
         if (map == null) {
             map = googleMap
@@ -102,12 +107,14 @@ class ContactsMapFragment :
     }
 
     override fun onDestroyView() {
-        map?.let {
-            val position = it.cameraPosition
-            preferences.setCameraPosition(position)
-        }
-
+        saveCameraPosition()
         super.onDestroyView()
+    }
+
+    private fun saveCameraPosition() {
+        map?.let {
+            preferences.setCameraPosition(it.cameraPosition)
+        }
     }
 
     fun notifyDataSetChanged() {


### PR DESCRIPTION
## Summary
- Save the current map camera position when ContactsMapFragment pauses
- Reuse the same save helper from onDestroyView
- Prevent stale shared_prefs/map.xml values from being reused when the app is backgrounded without destroying the Fragment view

## Verification
- git diff --check
- sh ./gradlew testDebugUnitTest
- sh ./gradlew compileDebugAndroidTestKotlin
- sh ./gradlew assembleDebug
- Installed the debug APK on a connected device, moved the map, pressed HOME, and confirmed shared_prefs/map.xml timestamp and coordinates were updated