### PR TITLE
Remove long press marker on contact and group selection

### DIFF
--- a/app/src/main/java/com/github/yuukis/businessmap/app/ContactsMapFragment.kt
+++ b/app/src/main/java/com/github/yuukis/businessmap/app/ContactsMapFragment.kt
@@ -162,6 +162,7 @@ class ContactsMapFragment :
             return false
         }
         val marker = contactMarkerHashMap[contact.hashCode()] ?: return false
+        removeLongPressMarker()
         if (animate) {
             currentMap.animateCamera(
                 CameraUpdateFactory.newCameraPosition(

--- a/app/src/main/java/com/github/yuukis/businessmap/app/ContactsMapFragment.kt
+++ b/app/src/main/java/com/github/yuukis/businessmap/app/ContactsMapFragment.kt
@@ -186,6 +186,10 @@ class ContactsMapFragment :
         return true
     }
 
+    fun clearLongPressMarker() {
+        removeLongPressMarker()
+    }
+
     override fun onInfoWindowClick(marker: Marker) {
         if (marker == longPressMarker) {
             val position = marker.position

--- a/app/src/main/java/com/github/yuukis/businessmap/app/MainActivity.kt
+++ b/app/src/main/java/com/github/yuukis/businessmap/app/MainActivity.kt
@@ -121,6 +121,7 @@ open class MainActivity : AppCompatActivity(),
                     viewModel = viewModel,
                     fragmentManager = supportFragmentManager,
                     onAboutClick = { AboutDialogFragment.showDialog(this) },
+                    onGroupSelected = ::handleGroupSelected,
                     onContactClick = ::handleContactClick,
                 )
             }
@@ -188,6 +189,14 @@ open class MainActivity : AppCompatActivity(),
 
     private fun mapFragment(): ContactsMapFragment? =
         supportFragmentManager.findFragmentById(R.id.contacts_map) as? ContactsMapFragment
+
+    private fun handleGroupSelected(index: Int) {
+        val previousIndex = viewModel.selectedGroupIndex.value
+        viewModel.selectGroup(index)
+        if (viewModel.selectedGroupIndex.value != previousIndex) {
+            mapFragment()?.clearLongPressMarker()
+        }
+    }
 
     private fun handleContactClick(contact: ContactsItem) {
         val animate = true
@@ -287,6 +296,7 @@ private fun MainScreen(
     viewModel: MainActivityViewModel,
     fragmentManager: FragmentManager,
     onAboutClick: () -> Unit,
+    onGroupSelected: (Int) -> Unit,
     onContactClick: (ContactsItem) -> Unit,
 ) {
     val groupList by viewModel.groupList.collectAsState()
@@ -304,7 +314,7 @@ private fun MainScreen(
             MainTopAppBar(
                 groupList = groupList,
                 selectedGroupIndex = selectedGroupIndex,
-                onGroupSelected = viewModel::selectGroup,
+                onGroupSelected = onGroupSelected,
                 onToggleContactsList = viewModel::toggleContactsListVisible,
                 onAboutClick = onAboutClick,
             )


### PR DESCRIPTION
## Summary
- Remove the temporary green long-press marker before showing a selected contact from the contacts list or same-location contact dialog
- Remove the temporary green marker when switching contact groups
- Keep the existing behavior for map tap, marker tap, and repeated long-press cleanup

## Verification
- git diff --check
- sh ./gradlew testDebugUnitTest
- sh ./gradlew compileDebugAndroidTestKotlin