### PR TITLE
InfoWindowの住所表示の折り返しを改善

### DIFF
--- a/app/src/main/java/com/github/yuukis/businessmap/app/ContactsMapFragment.kt
+++ b/app/src/main/java/com/github/yuukis/businessmap/app/ContactsMapFragment.kt
@@ -446,8 +446,7 @@ class ContactsMapFragment :
                     tvCompanyName.visibility = View.VISIBLE
                 }
 
-                val snippet = marker.snippet?.replace("[ 　]".toRegex(), "\n")
-                tvSnippet.text = snippet
+                tvSnippet.text = marker.snippet
                 tvSnippet.visibility = View.VISIBLE
 
                 val note = contacts.note

--- a/app/src/main/res/layout/marker_info_contents.xml
+++ b/app/src/main/res/layout/marker_info_contents.xml
@@ -20,8 +20,8 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center_horizontal"
-        android:ellipsize="end"
-        android:singleLine="true"
+        android:breakStrategy="high_quality"
+        android:maxWidth="@dimen/marker_info_window_text_max_width"
         android:textColor="#ff000000"
         android:textSize="16dp"
         android:textStyle="bold" />
@@ -34,6 +34,7 @@
         android:layout_marginBottom="2dp"
         android:background="@drawable/rounded_corner"
         android:ellipsize="end"
+        android:maxWidth="@dimen/marker_info_window_text_max_width"
         android:singleLine="true"
         android:textColor="#ff444444"
         android:textSize="10dp" />
@@ -47,7 +48,9 @@
             android:id="@+id/snippet"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:breakStrategy="high_quality"
             android:ellipsize="end"
+            android:maxWidth="@dimen/marker_info_window_text_max_width"
             android:textColor="#ff7f7f7f"
             android:textSize="14dp" />
 
@@ -63,6 +66,8 @@
             android:id="@+id/note"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:breakStrategy="high_quality"
+            android:maxWidth="@dimen/marker_info_window_text_max_width"
             android:textColor="#ff7f7f7f"
             android:textSize="14dp" />
     </LinearLayout>

--- a/app/src/main/res/values-sw600dp-land/dimens.xml
+++ b/app/src/main/res/values-sw600dp-land/dimens.xml
@@ -2,5 +2,6 @@
 <resources>
 
     <dimen name="contacts_list_drawer_width">320dp</dimen>
+    <dimen name="marker_info_window_text_max_width">300dp</dimen>
 
 </resources>

--- a/app/src/main/res/values-sw720dp/dimens.xml
+++ b/app/src/main/res/values-sw720dp/dimens.xml
@@ -2,5 +2,6 @@
 <resources>
 
     <dimen name="contacts_list_drawer_width">400dp</dimen>
+    <dimen name="marker_info_window_text_max_width">320dp</dimen>
 
 </resources>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -2,5 +2,6 @@
 <resources>
 
     <dimen name="contacts_list_drawer_width">-1px</dimen>
+    <dimen name="marker_info_window_text_max_width">260dp</dimen>
 
 </resources>


### PR DESCRIPTION
## 概要
- InfoWindow 内のテキストに最大幅を設定し、長い住所や名前が横に伸びすぎないようにしました
- 住所中の半角/全角スペースを強制改行に変換する処理を削除し、英語住所が縦長になりすぎないようにしました
- 通常マーカーと長押しで表示される緑色マーカーのどちらも、最大幅内で自然に折り返すようにしました

## 確認
- ./gradlew :app:testDebugUnitTest :app:compileDebugAndroidTestKotlin

## 補足
- Google Maps の InfoWindow は実際の見た目確認が必要なため、実機での日本語住所/英語住所/長押しマーカーの表示確認は別途行います