### PR TITLE
Android 9以降の地図起動クラッシュを修正

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,6 +18,10 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:label="@string/app_name"
         android:theme="@style/AppTheme" >
+        <uses-library
+            android:name="org.apache.http.legacy"
+            android:required="false" />
+
         <meta-data
             android:name="com.google.android.maps.v2.API_KEY"
             android:value="${mapsApiKey}" />


### PR DESCRIPTION
## 概要
- Google Maps の Dynamite モジュールが Apache HTTP legacy クラスを参照する端末で起動時にクラッシュする問題を修正
- AndroidManifest に org.apache.http.legacy を optional library として宣言

## 確認
- ./gradlew :app:processDebugManifest
- エミュレータで修正後 APK を起動し、AndroidRuntime の fatal crash が出ないことを確認